### PR TITLE
minors dependencies fixes 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ zip = { version = "0.6.6", default-features = false, features = ["time", "zstd"]
 # RGB-related deps
 amplify = "=4.5.0"
 bp-core = "=0.10.11"
-rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", branch = "master" }
+rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", branch = "rln_v0.10" }
 rgb-std = "=0.10.9"
 rgb-wallet = "=0.10.9"
 rgb_core = { package = "rgb-core", version = "=0.10.8" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,5 @@
 [toolchain]
-# TODO: revert to stable after rust 1.74 - see https://github.com/rust-lang/rust/issues/115188
-channel = "1.71"
+channel = "stable"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"


### PR DESCRIPTION
This is a minor change that require also updating the rust-lightning to compile it on my system

Idk if I am missing something related to rust 1.74 due https://github.com/rust-lang/rust/issues/115188


See commits for error description

Depending from https://github.com/RGB-Tools/rust-lightning/pull/3

