### PR TITLE
meta: fix rustc version 

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "stable"
+channel = "1.74"
 components = ["clippy", "rustfmt"]
 targets = []
 profile = "minimal"


### PR DESCRIPTION
Using rustc 1.70.0 and running the following command

cargo install --debug --path .

I get the following error
```
error: failed to compile `rgb-lightning-node v0.1.0 (/home/vincent/github/rgb-lightning-node)`, intermediate artifacts can be found at `/home/vincent/github/rgb-lightning-node/target`

Caused by:
  package `clap_builder v4.5.2` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.70.0
  Either upgrade to rustc 1.74 or newer, or use
  cargo update -p clap_builder@4.5.2 --precise ver
  where `ver` is the latest version of `clap_builder` supporting rustc
  1.70.0
```
So this should fix the minimum rust version to 1.74

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>