### PR TITLE
Add get_payment route and error handling for invalid payment hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The node currently exposes the following APIs:
 - `/failtransfers` (POST)
 - `/getassetmedia` (POST)
 - `/getchannelid` (POST)
+- `/getpayment` (POST)
 - `/init` (POST)
 - `/invoicestatus` (POST)
 - `/issueassetcfa` (POST)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -350,6 +350,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetChannelIdResponse'
+  /getpayment:
+    post:
+      tags:
+        - Payments
+      summary: Get a payment
+      description: Get a payment by its payment hash
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetPaymentRequest'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentResponse'
   /init:
     post:
       tags:
@@ -1404,6 +1422,17 @@ components:
         channel_id:
           type: string
           example: 8129afe1b1d7cf60d5e1bf4c04b09bec925ed4df5417ceee0484e24f816a105a
+    GetPaymentRequest:
+      type: object
+      properties:
+        payment_hash:
+          type: string
+          example: 5ca5d81b482b4015e7b14df7a27fe0a38c226273604ffd3b008b752571811938
+    GetPaymentResponse:
+      type: object
+      properties:
+        payment:
+          $ref: '#/components/schemas/Payment'
     HTLCStatus:
       type: string
       enum:

--- a/src/error.rs
+++ b/src/error.rs
@@ -144,6 +144,9 @@ pub enum APIError {
     #[error("Invalid onion data: {0}")]
     InvalidOnionData(String),
 
+    #[error("Invalid payment hash: {0}")]
+    InvalidPaymentHash(String),
+
     #[error("Invalid payment secret")]
     InvalidPaymentSecret,
 
@@ -236,6 +239,9 @@ pub enum APIError {
 
     #[error("Output below the dust limit")]
     OutputBelowDustLimit,
+
+    #[error("Payment not found: {0}")]
+    PaymentNotFound(String),
 
     #[error("Recipient ID already used")]
     RecipientIDAlreadyUsed,
@@ -406,6 +412,7 @@ impl IntoResponse for APIError {
             | APIError::InvalidNodeIds(_)
             | APIError::InvalidOnionData(_)
             | APIError::InvalidPassword(_)
+            | APIError::InvalidPaymentHash(_)
             | APIError::InvalidPaymentSecret
             | APIError::InvalidPeerInfo(_)
             | APIError::InvalidPrecision(_)
@@ -422,6 +429,7 @@ impl IntoResponse for APIError {
             | APIError::MediaFileNotProvided
             | APIError::MissingSwapPaymentPreimage
             | APIError::OutputBelowDustLimit
+            | APIError::PaymentNotFound(_)
             | APIError::UnsupportedBackupVersion { .. } => {
                 (StatusCode::BAD_REQUEST, self.to_string(), self.name())
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,12 +42,12 @@ use crate::routes::{
     address, asset_balance, asset_metadata, backup, btc_balance, change_password,
     check_indexer_url, check_proxy_endpoint, close_channel, connect_peer, create_utxos,
     decode_ln_invoice, decode_rgb_invoice, disconnect_peer, estimate_fee, fail_transfers,
-    get_asset_media, get_channel_id, init, invoice_status, issue_asset_cfa, issue_asset_nia,
-    issue_asset_uda, keysend, list_assets, list_channels, list_payments, list_peers, list_swaps,
-    list_transactions, list_transfers, list_unspents, ln_invoice, lock, maker_execute, maker_init,
-    network_info, node_info, open_channel, post_asset_media, refresh_transfers, restore,
-    rgb_invoice, send_asset, send_btc, send_onion_message, send_payment, shutdown, sign_message,
-    sync, taker, unlock,
+    get_asset_media, get_channel_id, get_payment, init, invoice_status, issue_asset_cfa,
+    issue_asset_nia, issue_asset_uda, keysend, list_assets, list_channels, list_payments,
+    list_peers, list_swaps, list_transactions, list_transfers, list_unspents, ln_invoice, lock,
+    maker_execute, maker_init, network_info, node_info, open_channel, post_asset_media,
+    refresh_transfers, restore, rgb_invoice, send_asset, send_btc, send_onion_message,
+    send_payment, shutdown, sign_message, sync, taker, unlock,
 };
 use crate::utils::{start_daemon, AppState, LOGS_DIR};
 
@@ -119,6 +119,7 @@ pub(crate) async fn app(args: LdkUserInfo) -> Result<(Router, Arc<AppState>), Ap
         .route("/failtransfers", post(fail_transfers))
         .route("/getassetmedia", post(get_asset_media))
         .route("/getchannelid", post(get_channel_id))
+        .route("/getpayment", post(get_payment))
         .route("/init", post(init))
         .route("/invoicestatus", post(invoice_status))
         .route("/issueassetcfa", post(issue_asset_cfa))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -533,6 +533,16 @@ pub(crate) struct GetChannelIdResponse {
     pub(crate) channel_id: String,
 }
 
+#[derive(Deserialize, Serialize)]
+pub(crate) struct GetPaymentRequest {
+    pub(crate) payment_hash: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct GetPaymentResponse {
+    pub(crate) payment: Payment,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 pub(crate) enum HTLCStatus {
     Pending,
@@ -2059,6 +2069,87 @@ pub(crate) async fn list_payments(
     }
 
     Ok(Json(ListPaymentsResponse { payments }))
+}
+
+pub(crate) async fn get_payment(
+    State(state): State<Arc<AppState>>,
+    WithRejection(Json(payload), _): WithRejection<Json<GetPaymentRequest>, APIError>,
+) -> Result<Json<GetPaymentResponse>, APIError> {
+    let payment_hash_vec = hex_str_to_vec(&payload.payment_hash);
+    if payment_hash_vec.is_none() || payment_hash_vec.as_ref().unwrap().len() != 32 {
+        return Err(APIError::InvalidPaymentHash(format!(
+            "{:?}",
+            payload.payment_hash
+        )));
+    }
+    let mut payment_hash = [0; 32];
+    payment_hash.copy_from_slice(&payment_hash_vec.unwrap());
+    let requested_payment_hash = PaymentHash(payment_hash);
+    let unlocked_state = state.check_unlocked().await?.clone().unwrap();
+
+    let inbound_payments = unlocked_state.inbound_payments();
+    let outbound_payments = unlocked_state.outbound_payments();
+
+    for (payment_hash, payment_info) in &inbound_payments {
+        if payment_hash == &requested_payment_hash {
+            let rgb_payment_info_path_inbound =
+                get_rgb_payment_info_path(payment_hash, &state.static_state.ldk_data_dir, true);
+
+            let (asset_amount, asset_id) = if rgb_payment_info_path_inbound.exists() {
+                let info = parse_rgb_payment_info(&rgb_payment_info_path_inbound);
+                (Some(info.amount), Some(info.contract_id.to_string()))
+            } else {
+                (None, None)
+            };
+
+            return Ok(Json(GetPaymentResponse {
+                payment: Payment {
+                    amt_msat: payment_info.amt_msat,
+                    asset_amount,
+                    asset_id,
+                    payment_hash: hex_str(&payment_hash.0),
+                    inbound: true,
+                    status: payment_info.status,
+                    created_at: payment_info.created_at,
+                    updated_at: payment_info.updated_at,
+                    payee_pubkey: payment_info.payee_pubkey.to_string(),
+                },
+            }));
+        }
+    }
+
+    for (payment_id, payment_info) in &outbound_payments {
+        let payment_hash = &PaymentHash(payment_id.0);
+        if payment_hash == &requested_payment_hash {
+            let rgb_payment_info_path_outbound =
+                get_rgb_payment_info_path(payment_hash, &state.static_state.ldk_data_dir, false);
+
+            let (asset_amount, asset_id) = if rgb_payment_info_path_outbound.exists() {
+                let info = parse_rgb_payment_info(&rgb_payment_info_path_outbound);
+                (Some(info.amount), Some(info.contract_id.to_string()))
+            } else {
+                (None, None)
+            };
+
+            return Ok(Json(GetPaymentResponse {
+                payment: Payment {
+                    amt_msat: payment_info.amt_msat,
+                    asset_amount,
+                    asset_id,
+                    payment_hash: hex_str(&payment_hash.0),
+                    inbound: false,
+                    status: payment_info.status,
+                    created_at: payment_info.created_at,
+                    updated_at: payment_info.updated_at,
+                    payee_pubkey: payment_info.payee_pubkey.to_string(),
+                },
+            }));
+        }
+    }
+    Err(APIError::PaymentNotFound(format!(
+        "{:?}",
+        &payload.payment_hash
+    )))
 }
 
 pub(crate) async fn list_peers(

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -24,14 +24,14 @@ use crate::routes::{
     DecodeLNInvoiceResponse, DecodeRGBInvoiceRequest, DecodeRGBInvoiceResponse,
     DisconnectPeerRequest, EmptyResponse, FailTransfersRequest, FailTransfersResponse,
     GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest, GetChannelIdResponse,
-    HTLCStatus, InitRequest, InitResponse, InvoiceStatus, InvoiceStatusRequest,
-    InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse, IssueAssetNIARequest,
-    IssueAssetNIAResponse, IssueAssetUDARequest, IssueAssetUDAResponse, KeysendRequest,
-    KeysendResponse, LNInvoiceRequest, LNInvoiceResponse, ListAssetsRequest, ListAssetsResponse,
-    ListChannelsResponse, ListPaymentsResponse, ListPeersResponse, ListSwapsResponse,
-    ListTransactionsRequest, ListTransactionsResponse, ListTransfersRequest, ListTransfersResponse,
-    ListUnspentsRequest, ListUnspentsResponse, MakerExecuteRequest, MakerInitRequest,
-    MakerInitResponse, NetworkInfoResponse, NodeInfoResponse, OpenChannelRequest,
+    GetPaymentRequest, GetPaymentResponse, HTLCStatus, InitRequest, InitResponse, InvoiceStatus,
+    InvoiceStatusRequest, InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse,
+    IssueAssetNIARequest, IssueAssetNIAResponse, IssueAssetUDARequest, IssueAssetUDAResponse,
+    KeysendRequest, KeysendResponse, LNInvoiceRequest, LNInvoiceResponse, ListAssetsRequest,
+    ListAssetsResponse, ListChannelsResponse, ListPaymentsResponse, ListPeersResponse,
+    ListSwapsResponse, ListTransactionsRequest, ListTransactionsResponse, ListTransfersRequest,
+    ListTransfersResponse, ListUnspentsRequest, ListUnspentsResponse, MakerExecuteRequest,
+    MakerInitRequest, MakerInitResponse, NetworkInfoResponse, NodeInfoResponse, OpenChannelRequest,
     OpenChannelResponse, Payment, Peer, PostAssetMediaResponse, RefreshRequest, RestoreRequest,
     RgbInvoiceRequest, RgbInvoiceResponse, SendAssetRequest, SendAssetResponse, SendBtcRequest,
     SendBtcResponse, SendPaymentRequest, SendPaymentResponse, SwapStatus, TakerRequest,
@@ -764,6 +764,24 @@ async fn list_payments(node_address: SocketAddr) -> Vec<Payment> {
         .await
         .unwrap()
         .payments
+}
+async fn get_payment(node_address: SocketAddr, payment_hash: &str) -> Payment {
+    println!("getting payment for node {node_address}");
+    let payload = GetPaymentRequest {
+        payment_hash: payment_hash.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{}/getpayment", node_address))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    _check_response_is_ok(res)
+        .await
+        .json::<GetPaymentResponse>()
+        .await
+        .unwrap()
+        .payment
 }
 
 async fn list_peers(node_address: SocketAddr) -> Vec<Peer> {

--- a/src/test/payment.rs
+++ b/src/test/payment.rs
@@ -59,19 +59,11 @@ async fn success() {
     let status = invoice_status(node2_addr, &invoice).await;
     assert!(matches!(status, InvoiceStatus::Succeeded));
 
-    let payments = list_payments(node1_addr).await;
-    let payment = payments
-        .iter()
-        .find(|p| p.payment_hash == decoded.payment_hash)
-        .unwrap();
+    let payment = get_payment(node1_addr, &decoded.payment_hash).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
-    let payments = list_payments(node2_addr).await;
-    let payment = payments
-        .iter()
-        .find(|p| p.payment_hash == decoded.payment_hash)
-        .unwrap();
+    let payment = get_payment(node2_addr, &decoded.payment_hash).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
@@ -89,19 +81,11 @@ async fn success() {
     .await;
 
     let decoded = decode_ln_invoice(node1_addr, &invoice).await;
-    let payments = list_payments(node1_addr).await;
-    let payment = payments
-        .iter()
-        .find(|p| p.payment_hash == decoded.payment_hash)
-        .unwrap();
+    let payment = get_payment(node1_addr, &decoded.payment_hash).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
-    let payments = list_payments(node2_addr).await;
-    let payment = payments
-        .iter()
-        .find(|p| p.payment_hash == decoded.payment_hash)
-        .unwrap();
+    let payment = get_payment(node2_addr, &decoded.payment_hash).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
@@ -111,19 +95,11 @@ async fn success() {
     let _ = send_payment(node1_addr, invoice.clone()).await;
 
     let decoded = decode_ln_invoice(node1_addr, &invoice).await;
-    let payments = list_payments(node1_addr).await;
-    let payment = payments
-        .iter()
-        .find(|p| p.payment_hash == decoded.payment_hash)
-        .unwrap();
+    let payment = get_payment(node1_addr, &decoded.payment_hash).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
-    let payments = list_payments(node2_addr).await;
-    let payment = payments
-        .iter()
-        .find(|p| p.payment_hash == decoded.payment_hash)
-        .unwrap();
+    let payment = get_payment(node2_addr, &decoded.payment_hash).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
@@ -133,19 +109,11 @@ async fn success() {
     let _ = send_payment(node2_addr, invoice.clone()).await;
 
     let decoded = decode_ln_invoice(node1_addr, &invoice).await;
-    let payments = list_payments(node1_addr).await;
-    let payment = payments
-        .iter()
-        .find(|p| p.payment_hash == decoded.payment_hash)
-        .unwrap();
+    let payment = get_payment(node1_addr, &decoded.payment_hash).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);
-    let payments = list_payments(node2_addr).await;
-    let payment = payments
-        .iter()
-        .find(|p| p.payment_hash == decoded.payment_hash)
-        .unwrap();
+    let payment = get_payment(node2_addr, &decoded.payment_hash).await;
     assert_eq!(payment.asset_id, Some(asset_id.clone()));
     assert_eq!(payment.asset_amount, asset_amount);
     assert_eq!(payment.status, HTLCStatus::Succeeded);


### PR DESCRIPTION
- Introduced a new API route `/getpayment` to retrieve payment details based on a provided payment hash.
- Added `InvalidPaymentHash` error variant to `APIError` for better error handling.
- Updated relevant tests to utilize the new `get_payment` function instead of listing payments.
- Fix to #51 