### PR TITLE
fix : Implement self-payment prevention and duplicate payment checks …

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -223,6 +223,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyResponse'
+  /decodeassetid:
+    post:
+      summary: Decode RGB asset ID to hexadecimal format
+      description: Convert RGB format asset ID (rgb:xxx) to hexadecimal format
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DecodeAssetIdRequest'
+      responses:
+        '200':
+          description: Asset ID encoding result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecodeAssetIdResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Locked'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /decodelninvoice:
     post:
       tags:
@@ -277,6 +300,29 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EmptyResponse'
+  /encodeassetid:
+    post:
+      summary: Encode hexadecimal asset ID to RGB format
+      description: Convert hexadecimal format asset ID to RGB format (rgb:xxx)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EncodeAssetIdRequest'
+      responses:
+        '200':
+          description: Asset ID decoding result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EncodeAssetIdResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Locked'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /estimatefee:
     post:
       tags:
@@ -1288,6 +1334,21 @@ components:
         skip_sync:
           type: boolean
           example: false
+    DecodeAssetIdRequest:
+      type: object
+      properties:
+        asset_id:
+          type: string
+          example: rgb:2dkSTbr-jFhznbPmo-TQafzswCN-av4gTsJjX-ttx6CNou5-M98k8Zd
+    DecodeAssetIdResponse:
+      type: object
+      properties:
+        hex_format:
+          type: string
+          example: aa1c3d3ef10424cf64e45ea93516c14766be91031c39715783a4f78bd7e64a8a
+        asset_id:
+          type: string
+          example: rgb:2dkSTbr-jFhznbPmo-TQafzswCN-av4gTsJjX-ttx6CNou5-M98k8Zd
     DecodeLNInvoiceRequest:
       type: object
       properties:
@@ -1359,6 +1420,21 @@ components:
         peer_pubkey:
           type: string
           example: 03b79a4bc1ec365524b4fab9a39eb133753646babb5a1da5c4bc94c53110b7795d
+    EncodeAssetIdRequest:
+      type: object
+      properties:
+        hex_format:
+          type: string
+          example: aa1c3d3ef10424cf64e45ea93516c14766be91031c39715783a4f78bd7e64a8a
+    EncodeAssetIdResponse:
+      type: object
+      properties:
+        hex_format:
+          type: string
+          example: aa1c3d3ef10424cf64e45ea93516c14766be91031c39715783a4f78bd7e64a8a
+        asset_id:
+          type: string
+          example: rgb:2dkSTbr-jFhznbPmo-TQafzswCN-av4gTsJjX-ttx6CNou5-M98k8Zd
     EmbeddedMedia:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1778,6 +1778,14 @@ components:
         asset_amount:
           type: integer
           example: 42
+        preimage:
+          type: string
+          description: Optional custom payment preimage (hex string, 32 bytes)
+          example: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        memo:
+          type: string
+          description: Optional memo/description for the invoice
+          example: "Payment for services"
     LNInvoiceResponse:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1968,6 +1968,10 @@ components:
         payee_pubkey:
           type: string
           example: 03b79a4bc1ec365524b4fab9a39eb133753646babb5a1da5c4bc94c53110b7795d
+        preimage:
+          type: string
+          description: Optional custom payment preimage (hex string, 32 bytes)
+          example: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
     Peer:
       type: object
       properties:

--- a/src/error.rs
+++ b/src/error.rs
@@ -147,6 +147,9 @@ pub enum APIError {
     #[error("Invalid payment hash: {0}")]
     InvalidPaymentHash(String),
 
+    #[error("Invalid payment preimage")]
+    InvalidPaymentPreimage,
+
     #[error("Invalid payment secret")]
     InvalidPaymentSecret,
 
@@ -415,6 +418,7 @@ impl IntoResponse for APIError {
             | APIError::InvalidOnionData(_)
             | APIError::InvalidPassword(_)
             | APIError::InvalidPaymentHash(_)
+            | APIError::InvalidPaymentPreimage
             | APIError::InvalidPaymentSecret
             | APIError::InvalidPeerInfo(_)
             | APIError::InvalidPrecision(_)

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use crate::ldk::stop_ldk;
 use crate::routes::{
     address, asset_balance, asset_metadata, backup, btc_balance, change_password,
     check_indexer_url, check_proxy_endpoint, close_channel, connect_peer, create_utxos,
-    decode_ln_invoice, decode_rgb_invoice, disconnect_peer, estimate_fee, fail_transfers,
+    decode_asset_id, decode_ln_invoice, decode_rgb_invoice, disconnect_peer, encode_asset_id, estimate_fee, fail_transfers,
     get_asset_media, get_channel_id, get_payment, get_swap, init, invoice_status, issue_asset_cfa,
     issue_asset_nia, issue_asset_uda, keysend, list_assets, list_channels, list_payments,
     list_peers, list_swaps, list_transactions, list_transfers, list_unspents, ln_invoice, lock,
@@ -112,9 +112,11 @@ pub(crate) async fn app(args: LdkUserInfo) -> Result<(Router, Arc<AppState>), Ap
         .route("/closechannel", post(close_channel))
         .route("/connectpeer", post(connect_peer))
         .route("/createutxos", post(create_utxos))
+        .route("/decodeassetid", post(decode_asset_id))
         .route("/decodelninvoice", post(decode_ln_invoice))
         .route("/decodergbinvoice", post(decode_rgb_invoice))
         .route("/disconnectpeer", post(disconnect_peer))
+        .route("/encodeassetid", post(encode_asset_id))
         .route("/estimatefee", post(estimate_fee))
         .route("/failtransfers", post(fail_transfers))
         .route("/getassetmedia", post(get_asset_media))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -820,6 +820,7 @@ pub(crate) struct Payment {
     pub(crate) created_at: u64,
     pub(crate) updated_at: u64,
     pub(crate) payee_pubkey: String,
+    pub(crate) preimage: Option<String>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -2024,6 +2025,7 @@ pub(crate) async fn list_payments(
             created_at: payment_info.created_at,
             updated_at: payment_info.updated_at,
             payee_pubkey: payment_info.payee_pubkey.to_string(),
+            preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
         });
     }
 
@@ -2050,6 +2052,7 @@ pub(crate) async fn list_payments(
             created_at: payment_info.created_at,
             updated_at: payment_info.updated_at,
             payee_pubkey: payment_info.payee_pubkey.to_string(),
+            preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
         });
     }
 
@@ -2094,6 +2097,7 @@ pub(crate) async fn get_payment(
                     created_at: payment_info.created_at,
                     updated_at: payment_info.updated_at,
                     payee_pubkey: payment_info.payee_pubkey.to_string(),
+                    preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
                 },
             }));
         }
@@ -2123,6 +2127,7 @@ pub(crate) async fn get_payment(
                     created_at: payment_info.created_at,
                     updated_at: payment_info.updated_at,
                     payee_pubkey: payment_info.payee_pubkey.to_string(),
+                    preimage: payment_info.preimage.map(|p| hex_str(&p.0)),
                 },
             }));
         }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -12,7 +12,7 @@ use hex::DisplayHex;
 use lightning::ln::bolt11_payment::{
     payment_parameters_from_invoice, payment_parameters_from_zero_amount_invoice,
 };
-use lightning::ln::invoice_utils::create_invoice_from_channelmanager;
+use lightning::ln::invoice_utils::create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_hash;
 use lightning::ln::types::ChannelId;
 use lightning::offers::offer::{self, Offer};
 use lightning::onion_message::messenger::Destination;
@@ -711,6 +711,8 @@ pub(crate) struct LNInvoiceRequest {
     pub(crate) expiry_sec: u32,
     pub(crate) asset_id: Option<String>,
     pub(crate) asset_amount: Option<u64>,
+    pub(crate) preimage: Option<String>,
+    pub(crate) memo: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -2392,14 +2394,33 @@ pub(crate) async fn ln_invoice(
             RgbLibNetwork::Regtest => Currency::Regtest,
             RgbLibNetwork::Signet => Currency::Signet,
         };
-        let invoice = match create_invoice_from_channelmanager(
+
+        let description = payload.memo.unwrap_or_else(|| "ldk-tutorial-node".to_string());
+
+        let (payment_hash, preimage_to_store) = if let Some(ref preimage_hex) = payload.preimage {
+            let preimage_bytes = hex_str_to_vec(&preimage_hex)
+                .and_then(|data| data.try_into().ok())
+                .ok_or_else(|| APIError::InvalidPaymentPreimage)?;
+            let preimage = PaymentPreimage(preimage_bytes);
+            let payment_hash = PaymentHash(Sha256::hash(&preimage.0).to_byte_array());
+            (payment_hash, Some(preimage))
+        } else {
+            let preimage = PaymentPreimage(unlocked_state.keys_manager.get_secure_random_bytes());
+            let payment_hash = PaymentHash(Sha256::hash(&preimage.0).to_byte_array());
+            (payment_hash, Some(preimage))
+        };
+        
+        let invoice = match create_invoice_from_channelmanager_and_duration_since_epoch_with_payment_hash(
             &unlocked_state.channel_manager,
             unlocked_state.keys_manager.clone(),
             state.static_state.logger.clone(),
             currency,
             payload.amt_msat,
-            "ldk-tutorial-node".to_string(),
+            description,
+            std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH)
+                .expect("for the foreseeable future this shouldn't happen"),
             payload.expiry_sec,
+            payment_hash,
             None,
             contract_id,
             payload.asset_amount,
@@ -2413,7 +2434,7 @@ pub(crate) async fn ln_invoice(
         unlocked_state.add_inbound_payment(
             payment_hash,
             PaymentInfo {
-                preimage: None,
+                preimage: preimage_to_store,
                 secret: Some(*invoice.payment_secret()),
                 status: HTLCStatus::Pending,
                 amt_msat: payload.amt_msat,


### PR DESCRIPTION
Fix: Prevent self-payments and protect against pending invoice re-payments

1. 	1.	Self-payments can cause the invoice to remain in a pending state — added a check to prevent self-payments.
2. 	2.	Re-attempting payment on a pending invoice may fail and lead to force-closed channels — added a check in send_payment to avoid this edge case.
