### PR TITLE
add same_invoice_twice test

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,9 @@ pub enum APIError {
     #[error("Cannot call other APIs while node is changing state")]
     ChangingState,
 
+    #[error("Another payment for this invoice is already in status {0}")]
+    DuplicatePayment(String),
+
     #[error("The swap offer has expired")]
     ExpiredSwapOffer,
 
@@ -442,6 +445,7 @@ impl IntoResponse for APIError {
             | APIError::CannotEstimateFees
             | APIError::CannotFailBatchTransfer
             | APIError::ChangingState
+            | APIError::DuplicatePayment(_)
             | APIError::FailedBdkSync(_)
             | APIError::FailedBitcoindConnection(_)
             | APIError::FailedBroadcast(_)

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -633,7 +633,7 @@ async fn _with_ln_balance_checks(
         let final_ln_balance_rgb = initial_ln_balance_rgb.unwrap() - asset_amount.unwrap();
         wait_for_ln_balance(node_address, asset_id, final_ln_balance_rgb).await;
     }
-    _wait_for_ln_payment(node_address, payment_hash, HTLCStatus::Succeeded).await;
+    wait_for_ln_payment(node_address, payment_hash, HTLCStatus::Succeeded).await;
     if let Some(asset_id) = &asset_id {
         let counterparty_final_ln_balance =
             counterparty_initial_ln_balance_rgb.unwrap() + asset_amount.unwrap();
@@ -644,7 +644,7 @@ async fn _with_ln_balance_checks(
         )
         .await;
     }
-    _wait_for_ln_payment(
+    wait_for_ln_payment(
         counterparty_node_address,
         payment_hash,
         HTLCStatus::Succeeded,
@@ -691,7 +691,7 @@ async fn keysend(
     asset_amount: Option<u64>,
 ) -> Payment {
     let keysend = _keysend_raw(node_address, dest_pubkey, amt_msat, asset_id, asset_amount).await;
-    _wait_for_ln_payment(node_address, &keysend.payment_hash, HTLCStatus::Succeeded).await
+    wait_for_ln_payment(node_address, &keysend.payment_hash, HTLCStatus::Succeeded).await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1320,7 +1320,7 @@ async fn send_payment_with_status(
     expected_status: HTLCStatus,
 ) -> Payment {
     let send_payment = send_payment_raw(node_address, invoice).await;
-    _wait_for_ln_payment(
+    wait_for_ln_payment(
         node_address,
         // TODO: remove unwrap once RGB offers are enabled
         &send_payment.payment_hash.unwrap(),
@@ -1463,7 +1463,7 @@ async fn wait_for_usable_channels(node_address: SocketAddr, expected_num_usable_
     }
 }
 
-async fn _wait_for_ln_payment(
+async fn wait_for_ln_payment(
     node_address: SocketAddr,
     payment_hash: &str,
     expected_status: HTLCStatus,
@@ -1480,7 +1480,7 @@ async fn _wait_for_ln_payment(
             return payment;
         }
         if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 40.0 {
-            panic!("cannot find successful payment")
+            panic!("cannot find payment in status {expected_status}")
         }
     }
 }


### PR DESCRIPTION
This PR tries to reproduce the bug related to paying the same invoice twice, as reported in https://github.com/RGB-Tools/rgb-lightning-node/pull/58.
The test doesn't include the checks for the pyament/invoice status because we know there's a bug there, but the fix for that would prevent us to see a bigger bug that, as reported, should be that the channel gets force-closed. Once we manage to reproduce that bug, I'll add some more checks to this test.