### PR TITLE
Add `rln-cli` Command-Line Interface and Makefile Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ rust-version = "1.85.0"
 [[bin]]
 name = "rgb-lightning-node"
 
+[[bin]]
+name = "rln-cli"
+path = "src/cli.rs"
+
 [dependencies]
 amplify = { version = "=4.8.1", default-features = false }
 anyhow = "1.0.93"
@@ -20,9 +24,10 @@ bitcoin = "0.32"
 bitcoin-bech32 = "0.13"
 chacha20poly1305 = { version = "0.10.1", features = ["stream"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-clap = "4.5.20"
+clap = { version = "4.5.20", features = ["derive"] }
 dirs = "5.0.1"
 futures = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }
 hex = { package = "hex-conservative", version = "0.3.0", default-features = false }
 lightning = { version = "0.0.125", features = ["max_level_trace"], path = "./rust-lightning/lightning" }
 lightning-background-processor = { version = "0.0.125", features = ["futures"], path = "./rust-lightning/lightning-background-processor" }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,118 @@
+.PHONY: help build build-cli build-release build-cli-release test check clean install install-cli run-node run-cli demo
+
+help: ## Show this help message
+	@echo 'Usage: make [target]'
+	@echo ''
+	@echo 'Available targets:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+
+build: ## Build the RGB Lightning Node (debug)
+	cargo build --bin rgb-lightning-node
+
+build-cli: ## Build the CLI (debug)
+	cargo build --bin rln-cli
+
+build-release: ## Build the RGB Lightning Node (release)
+	cargo build --release --bin rgb-lightning-node
+
+build-cli-release: ## Build the CLI (release)
+	cargo build --release --bin rln-cli
+
+build-all: build-release build-cli-release ## Build both node and CLI (release)
+
+test: ## Run tests
+	cargo test
+
+check: ## Check code (without building)
+	cargo check --all-targets
+
+check-cli: ## Check CLI code
+	cargo check --bin rln-cli
+
+clean: ## Clean build artifacts
+	cargo clean
+
+install: build-release ## Install RGB Lightning Node
+	cargo install --path . --bin rgb-lightning-node
+
+install-cli: build-cli-release ## Install CLI
+	cargo install --path . --bin rln-cli
+
+install-all: ## Install both node and CLI
+	cargo install --path . --bin rgb-lightning-node
+	cargo install --path . --bin rln-cli
+
+run-node: ## Run RGB Lightning Node (requires arguments)
+	@echo "Usage: make run-node ARGS='<storage-dir> [options]'"
+	@echo "Example: make run-node ARGS='./data --network testnet'"
+	cargo run --bin rgb-lightning-node -- $(ARGS)
+
+run-cli: ## Run CLI (requires command)
+	@echo "Usage: make run-cli CMD='<command>'"
+	@echo "Example: make run-cli CMD='node info'"
+	cargo run --bin rln-cli -- $(CMD)
+
+demo: build-cli-release ## Run CLI demo script
+	@echo "Running CLI demo..."
+	@./examples/cli_demo.sh
+
+clippy: ## Run clippy linter
+	cargo clippy --all-targets -- -D warnings
+
+fmt: ## Format code
+	cargo fmt --all
+
+fmt-check: ## Check code formatting
+	cargo fmt --all -- --check
+
+doc: ## Generate documentation
+	cargo doc --no-deps --open
+
+# Development helpers
+dev-node: ## Run node in development mode (with example data dir)
+	@mkdir -p ./dev-data
+	cargo run --bin rgb-lightning-node -- ./dev-data --network regtest
+
+# CLI convenience targets
+cli-help: build-cli ## Show CLI help
+	cargo run --bin rln-cli -- --help
+
+cli-version: build-cli ## Show CLI version
+	cargo run --bin rln-cli -- --version
+
+# Quick CLI commands (assumes node is running on localhost:3001)
+cli-node-info: build-cli ## Get node info
+	cargo run --bin rln-cli -- node info
+
+cli-list-assets: build-cli ## List RGB assets
+	cargo run --bin rln-cli -- rgb list-assets
+
+cli-list-channels: build-cli ## List Lightning channels
+	cargo run --bin rln-cli -- channel list
+
+cli-list-peers: build-cli ## List Lightning peers
+	cargo run --bin rln-cli -- peer list
+
+cli-list-payments: build-cli ## List Lightning payments
+	cargo run --bin rln-cli -- payment list
+
+cli-btc-balance: build-cli ## Get BTC balance
+	cargo run --bin rln-cli -- onchain btc-balance
+
+# Installation check
+check-install: ## Check if binaries are installed
+	@which rgb-lightning-node && echo "✓ rgb-lightning-node is installed" || echo "✗ rgb-lightning-node not found"
+	@which rln-cli && echo "✓ rln-cli is installed" || echo "✗ rln-cli not found"
+
+# Create example directory structure
+setup-example: ## Set up example directory structure
+	@mkdir -p examples
+	@mkdir -p dev-data
+	@echo "✓ Created example directories"
+
+# Release build for distribution
+release: clean build-all ## Create release builds
+	@echo "✓ Release builds created:"
+	@ls -lh target/release/rgb-lightning-node
+	@ls -lh target/release/rln-cli
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,75 @@ running:
 cargo install --locked --debug --path .
 ```
 
+### CLI Tool
+
+The project includes `rln-cli`, a command-line interface tool for interacting with the RGB Lightning Node. To build and install the CLI:
+
+```sh
+# Build the CLI (release mode recommended)
+cargo build --release --bin rln-cli
+
+# Or use the Makefile
+make build-cli-release
+
+# Optional: Install system-wide (adds to ~/.cargo/bin)
+cargo install --path . --bin rln-cli
+```
+
+The CLI binary will be available at `target/release/rln-cli` or, if installed, as `rln-cli` in your PATH.
+
+#### Adding CLI to PATH
+
+If you haven't installed the CLI system-wide, you can add it to your PATH:
+
+```sh
+# Add to ~/.bashrc or ~/.zshrc
+export PATH="$HOME/.cargo/bin:$PATH"
+
+# Or use the binary directly from the build directory (replace with your path)
+export PATH="$(pwd)/target/release:$PATH"
+
+# Reload your shell configuration
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+#### CLI Quick Start
+
+```sh
+# Configure CLI (optional, can also use --server flag)
+export RLN_SERVER_URL=http://localhost:3001
+export RLN_AUTH_TOKEN=your_token_here  # if authentication is enabled
+
+# Get node information
+rln-cli node info
+
+# List RGB assets
+rln-cli rgb list-assets
+
+# List Lightning channels
+rln-cli channel list
+
+# Get help
+rln-cli --help
+rln-cli node --help
+```
+
+#### CLI Documentation
+
+For complete CLI documentation and usage examples:
+- Run `rln-cli --help` for command reference
+- See `examples/cli_demo.sh` for interactive examples
+
+The CLI provides access to all API endpoints organized into 8 command groups:
+- **node** - Node management (init, unlock, info, backup, etc.)
+- **onchain** - Bitcoin operations (balance, addresses, transactions)
+- **rgb** - RGB asset operations (issue, send, list assets)
+- **channel** - Lightning channel operations (open, close, list)
+- **peer** - Lightning peer operations (connect, disconnect, list)
+- **payment** - Lightning payments (send, keysend, list)
+- **invoice** - Lightning invoices (create, decode, status)
+- **swap** - Asset swap operations (maker, taker, list)
+
 ## Run
 
 In order to operate, the node will need:

--- a/examples/cli_demo.sh
+++ b/examples/cli_demo.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+# RGB Lightning Node CLI Demo Script
+# This script demonstrates common CLI operations
+
+set -e
+
+# Configuration
+SERVER_URL="${RLN_SERVER_URL:-http://localhost:3001}"
+AUTH_TOKEN="${RLN_AUTH_TOKEN:-}"
+CLI="./target/release/rln-cli"
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Helper function to print section headers
+print_section() {
+    echo -e "\n${BLUE}===================================================${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}===================================================${NC}\n"
+}
+
+# Helper function to print commands
+print_command() {
+    echo -e "${GREEN}$ $1${NC}"
+}
+
+# Helper function to print info
+print_info() {
+    echo -e "${YELLOW}ℹ $1${NC}"
+}
+
+# Check if CLI binary exists
+if [ ! -f "$CLI" ]; then
+    print_info "CLI binary not found. Building..."
+    cargo build --release --bin rln-cli
+fi
+
+# Export environment variables
+export RLN_SERVER_URL="$SERVER_URL"
+if [ -n "$AUTH_TOKEN" ]; then
+    export RLN_AUTH_TOKEN="$AUTH_TOKEN"
+fi
+
+print_section "RGB Lightning Node CLI Demo"
+
+# ============================
+# Node Information
+# ============================
+print_section "1. Getting Node Information"
+
+print_command "$CLI node info"
+$CLI node info
+
+print_command "$CLI node network-info"
+$CLI node network-info
+
+# ============================
+# On-Chain Operations
+# ============================
+print_section "2. On-Chain Operations"
+
+print_info "Getting a new Bitcoin address..."
+print_command "$CLI onchain address"
+ADDRESS_RESULT=$($CLI onchain address)
+echo "$ADDRESS_RESULT"
+
+print_info "Checking BTC balance..."
+print_command "$CLI onchain btc-balance"
+$CLI onchain btc-balance
+
+print_info "Listing unspent outputs..."
+print_command "$CLI onchain list-unspents"
+$CLI onchain list-unspents
+
+# ============================
+# RGB Asset Operations
+# ============================
+print_section "3. RGB Asset Operations"
+
+print_info "Listing all RGB assets..."
+print_command "$CLI rgb list-assets"
+ASSETS=$($CLI rgb list-assets)
+echo "$ASSETS"
+
+# Extract first asset ID if available
+ASSET_ID=$(echo "$ASSETS" | jq -r '.nia[0].asset_id // .cfa[0].asset_id // .uda[0].asset_id // empty' 2>/dev/null || echo "")
+
+if [ -n "$ASSET_ID" ]; then
+    print_info "Found asset: $ASSET_ID"
+    
+    print_command "$CLI rgb asset-balance $ASSET_ID"
+    $CLI rgb asset-balance "$ASSET_ID"
+    
+    print_command "$CLI rgb asset-metadata $ASSET_ID"
+    $CLI rgb asset-metadata "$ASSET_ID"
+    
+    print_command "$CLI rgb list-transfers $ASSET_ID"
+    $CLI rgb list-transfers "$ASSET_ID"
+else
+    print_info "No assets found. You can issue a new asset with:"
+    echo "  $CLI rgb issue-nia --amounts 1000000 DEMO 'Demo Token' --precision 2"
+fi
+
+# ============================
+# Lightning Network Operations
+# ============================
+print_section "4. Lightning Network Operations"
+
+print_info "Listing connected peers..."
+print_command "$CLI peer list"
+$CLI peer list
+
+print_info "Listing channels..."
+print_command "$CLI channel list"
+$CLI channel list
+
+print_info "Listing payments..."
+print_command "$CLI payment list"
+$CLI payment list
+
+# ============================
+# Asset Swaps
+# ============================
+print_section "5. Asset Swap Operations"
+
+print_info "Listing swaps..."
+print_command "$CLI swap list"
+$CLI swap list
+
+# ============================
+# Example Commands
+# ============================
+print_section "Example Commands Reference"
+
+cat << 'EOF'
+# Issue a new NIA asset (fungible token)
+./target/release/rln-cli rgb issue-nia \
+  --amounts 1000000 \
+  DEMO \
+  "Demo Token" \
+  --precision 2
+
+# Create UTXOs for RGB operations
+./target/release/rln-cli rgb create-utxos 5 32500 5.0
+
+# Get an RGB invoice to receive assets
+./target/release/rln-cli rgb rgb-invoice \
+  --min-confirmations 1 \
+  rgb:YOUR_ASSET_ID \
+  --amount 100 \
+  --duration-seconds 86400
+
+# Connect to a Lightning peer
+./target/release/rln-cli peer connect \
+  03pubkey@host:port
+
+# Open a vanilla Lightning channel
+./target/release/rln-cli channel open \
+  03pubkey@host:port \
+  30000 \
+  --push-msat 1000000 \
+  --public
+
+# Open an RGB Lightning channel
+./target/release/rln-cli channel open \
+  03pubkey@host:port \
+  30010 \
+  --asset-amount 100 \
+  --asset-id rgb:YOUR_ASSET_ID \
+  --public
+
+# Create a Lightning invoice
+./target/release/rln-cli invoice ln-invoice \
+  3000000 \
+  --expiry-sec 420
+
+# Send a Lightning payment
+./target/release/rln-cli payment send lnbc...
+
+# Send a keysend payment
+./target/release/rln-cli payment keysend \
+  03pubkey \
+  3000000
+
+# Initialize a maker swap
+./target/release/rln-cli swap maker-init \
+  30 \
+  10 \
+  rgb:FROM_ASSET \
+  rgb:TO_ASSET \
+  --timeout-sec 300
+
+# Backup the node
+./target/release/rln-cli node backup \
+  /path/to/backup.zip \
+  "password"
+
+# Sign a message
+./target/release/rln-cli node sign-message "Hello, RGB!"
+
+# Estimate on-chain fee
+./target/release/rln-cli onchain estimate-fee 6
+
+# Send BTC on-chain
+./target/release/rln-cli onchain send-btc \
+  10000 \
+  bcrt1qaddress... \
+  5.0
+
+EOF
+
+print_section "Demo Complete!"
+print_info "For more information, see CLI_README.md"
+print_info "Run '$CLI --help' to see all available commands"
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,1232 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use reqwest::multipart;
+use serde_json::Value;
+
+type ApiResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+#[derive(Parser)]
+#[command(name = "rln-cli")]
+#[command(about = "RGB Lightning Node CLI", long_about = None)]
+#[command(version)]
+struct Cli {
+    /// Server URL
+    #[arg(
+        short,
+        long,
+        env = "RLN_SERVER_URL",
+        default_value = "http://localhost:3001"
+    )]
+    server: String,
+
+    /// Authentication bearer token
+    #[arg(short, long, env = "RLN_AUTH_TOKEN")]
+    token: Option<String>,
+
+    /// Pretty print JSON output
+    #[arg(short, long, default_value = "true")]
+    pretty: bool,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Node management operations
+    Node {
+        #[command(subcommand)]
+        command: NodeCommands,
+    },
+    /// On-chain Bitcoin operations
+    Onchain {
+        #[command(subcommand)]
+        command: OnchainCommands,
+    },
+    /// RGB asset operations
+    Rgb {
+        #[command(subcommand)]
+        command: RgbCommands,
+    },
+    /// Lightning channel operations
+    Channel {
+        #[command(subcommand)]
+        command: ChannelCommands,
+    },
+    /// Lightning peer operations
+    Peer {
+        #[command(subcommand)]
+        command: PeerCommands,
+    },
+    /// Lightning payment operations
+    Payment {
+        #[command(subcommand)]
+        command: PaymentCommands,
+    },
+    /// Lightning invoice operations
+    Invoice {
+        #[command(subcommand)]
+        command: InvoiceCommands,
+    },
+    /// Asset swap operations
+    Swap {
+        #[command(subcommand)]
+        command: SwapCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum NodeCommands {
+    /// Initialize a new node
+    Init {
+        /// Password for encrypting the mnemonic
+        password: String,
+    },
+    /// Unlock the node
+    Unlock {
+        /// Password to decrypt the mnemonic
+        password: String,
+        /// Bitcoin RPC username
+        #[arg(long)]
+        bitcoind_rpc_username: String,
+        /// Bitcoin RPC password
+        #[arg(long)]
+        bitcoind_rpc_password: String,
+        /// Bitcoin RPC host
+        #[arg(long)]
+        bitcoind_rpc_host: String,
+        /// Bitcoin RPC port
+        #[arg(long)]
+        bitcoind_rpc_port: u16,
+        /// Indexer URL (electrum or esplora)
+        #[arg(long)]
+        indexer_url: Option<String>,
+        /// RGB proxy endpoint
+        #[arg(long)]
+        proxy_endpoint: Option<String>,
+        /// Announce addresses (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        announce_addresses: Vec<String>,
+        /// Announce alias
+        #[arg(long)]
+        announce_alias: Option<String>,
+    },
+    /// Lock the node
+    Lock,
+    /// Get node information
+    Info,
+    /// Get network information
+    NetworkInfo,
+    /// Backup the node
+    Backup {
+        /// Path for the backup file
+        backup_path: String,
+        /// Password for encrypting the backup
+        password: String,
+    },
+    /// Restore the node from backup
+    Restore {
+        /// Path to the backup file
+        backup_path: String,
+        /// Password to decrypt the backup
+        password: String,
+    },
+    /// Change password
+    ChangePassword {
+        /// Old password
+        old_password: String,
+        /// New password
+        new_password: String,
+    },
+    /// Check indexer URL
+    CheckIndexer {
+        /// Indexer URL to check
+        indexer_url: String,
+    },
+    /// Check proxy endpoint
+    CheckProxy {
+        /// Proxy URL to check
+        proxy_url: String,
+    },
+    /// Revoke authentication token
+    RevokeToken {
+        /// Token to revoke
+        token: String,
+    },
+    /// Send onion message
+    SendOnionMessage {
+        /// Node IDs for the path (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        node_ids: Vec<String>,
+        /// TLV type
+        tlv_type: u64,
+        /// Data (hex string)
+        data: String,
+    },
+    /// Shutdown the node
+    Shutdown,
+    /// Sign a message
+    SignMessage {
+        /// Message to sign
+        message: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum OnchainCommands {
+    /// Get a new Bitcoin address
+    Address,
+    /// Get BTC balance
+    BtcBalance {
+        /// Skip sync
+        #[arg(long)]
+        skip_sync: bool,
+    },
+    /// Estimate fee
+    EstimateFee {
+        /// Number of blocks for confirmation target
+        blocks: u16,
+    },
+    /// List transactions
+    ListTransactions {
+        /// Skip sync
+        #[arg(long)]
+        skip_sync: bool,
+    },
+    /// List unspent outputs
+    ListUnspents {
+        /// Skip sync
+        #[arg(long)]
+        skip_sync: bool,
+    },
+    /// Send BTC
+    SendBtc {
+        /// Amount in satoshis
+        amount: u64,
+        /// Destination address
+        address: String,
+        /// Fee rate (sat/vB)
+        fee_rate: u64,
+        /// Skip sync
+        #[arg(long)]
+        skip_sync: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum RgbCommands {
+    /// Get asset balance
+    AssetBalance {
+        /// Asset ID
+        asset_id: String,
+    },
+    /// Get asset metadata
+    AssetMetadata {
+        /// Asset ID
+        asset_id: String,
+    },
+    /// Create UTXOs for RGB operations
+    CreateUtxos {
+        /// Create up to this number (instead of exactly this number)
+        #[arg(long)]
+        up_to: bool,
+        /// Number of UTXOs
+        num: u8,
+        /// Size of each UTXO in satoshis
+        size: u32,
+        /// Fee rate (sat/vB)
+        fee_rate: u64,
+        /// Skip sync
+        #[arg(long)]
+        skip_sync: bool,
+    },
+    /// Decode RGB invoice
+    DecodeInvoice {
+        /// RGB invoice string
+        invoice: String,
+    },
+    /// Fail RGB transfers
+    FailTransfers {
+        /// Batch transfer index
+        #[arg(long)]
+        batch_transfer_idx: Option<i32>,
+        /// Only fail transfers with no asset
+        #[arg(long)]
+        no_asset_only: bool,
+        /// Skip sync
+        #[arg(long)]
+        skip_sync: bool,
+    },
+    /// Get asset media
+    GetMedia {
+        /// Media digest
+        digest: String,
+    },
+    /// Issue CFA asset
+    IssueCfa {
+        /// Amounts (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        amounts: Vec<u64>,
+        /// Asset name
+        name: String,
+        /// Asset details
+        #[arg(long)]
+        details: Option<String>,
+        /// Precision
+        #[arg(long, default_value = "0")]
+        precision: u8,
+        /// File digest for media
+        #[arg(long)]
+        file_digest: Option<String>,
+    },
+    /// Issue NIA asset
+    IssueNia {
+        /// Amounts (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        amounts: Vec<u64>,
+        /// Asset ticker
+        ticker: String,
+        /// Asset name
+        name: String,
+        /// Precision
+        #[arg(long, default_value = "0")]
+        precision: u8,
+    },
+    /// Issue UDA asset
+    IssueUda {
+        /// Asset ticker
+        ticker: String,
+        /// Asset name
+        name: String,
+        /// Asset details
+        #[arg(long)]
+        details: Option<String>,
+        /// Precision
+        #[arg(long, default_value = "0")]
+        precision: u8,
+        /// Media file digest
+        #[arg(long)]
+        media_file_digest: Option<String>,
+        /// Attachment file digests (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        attachments_file_digests: Vec<String>,
+    },
+    /// List assets
+    ListAssets {
+        /// Filter by asset schemas (comma-separated: Nia,Uda,Cfa)
+        #[arg(long, value_delimiter = ',')]
+        filter_schemas: Vec<String>,
+    },
+    /// List transfers for an asset
+    ListTransfers {
+        /// Asset ID
+        asset_id: String,
+    },
+    /// Post asset media
+    PostMedia {
+        /// Path to media file
+        file_path: String,
+    },
+    /// Refresh transfers
+    RefreshTransfers {
+        /// Skip sync
+        #[arg(long)]
+        skip_sync: bool,
+    },
+    /// Get RGB invoice
+    RgbInvoice {
+        /// Asset ID
+        asset_id: String,
+        /// Amount
+        #[arg(long)]
+        amount: Option<u64>,
+        /// Duration in seconds
+        #[arg(long)]
+        duration_seconds: Option<u32>,
+        /// Minimum confirmations
+        #[arg(long, default_value = "1")]
+        min_confirmations: u8,
+        /// Use witness recipient
+        #[arg(long)]
+        witness: bool,
+    },
+    /// Send RGB asset
+    SendAsset {
+        /// Asset ID
+        asset_id: String,
+        /// Amount
+        amount: u64,
+        /// Recipient ID (from invoice)
+        recipient_id: String,
+        /// Donation (no change)
+        #[arg(long)]
+        donation: bool,
+        /// Fee rate (sat/vB)
+        fee_rate: u64,
+        /// Minimum confirmations
+        #[arg(long, default_value = "1")]
+        min_confirmations: u8,
+        /// Transport endpoints (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        transport_endpoints: Vec<String>,
+        /// Skip sync
+        #[arg(long)]
+        skip_sync: bool,
+    },
+    /// Sync RGB wallet
+    Sync,
+}
+
+#[derive(Subcommand)]
+enum ChannelCommands {
+    /// Open a channel
+    Open {
+        /// Peer pubkey@host:port
+        peer: String,
+        /// Channel capacity in satoshis
+        capacity_sat: u64,
+        /// Push amount in msats
+        #[arg(long, default_value = "0")]
+        push_msat: u64,
+        /// RGB asset amount
+        #[arg(long)]
+        asset_amount: Option<u64>,
+        /// RGB asset ID
+        #[arg(long)]
+        asset_id: Option<String>,
+        /// Make channel public
+        #[arg(long)]
+        public: bool,
+        /// Use anchors
+        #[arg(long, default_value = "true")]
+        with_anchors: bool,
+        /// Fee base in msats
+        #[arg(long)]
+        fee_base_msat: Option<u32>,
+        /// Fee proportional millionths
+        #[arg(long)]
+        fee_proportional_millionths: Option<u32>,
+        /// Temporary channel ID
+        #[arg(long)]
+        temporary_channel_id: Option<String>,
+    },
+    /// Close a channel
+    Close {
+        /// Channel ID
+        channel_id: String,
+        /// Peer pubkey
+        peer_pubkey: String,
+        /// Force close
+        #[arg(long)]
+        force: bool,
+    },
+    /// Get channel ID from temporary channel ID
+    GetId {
+        /// Temporary channel ID
+        temporary_channel_id: String,
+    },
+    /// List channels
+    List,
+}
+
+#[derive(Subcommand)]
+enum PeerCommands {
+    /// Connect to a peer
+    Connect {
+        /// Peer pubkey@host:port
+        peer_pubkey_and_addr: String,
+    },
+    /// Disconnect from a peer
+    Disconnect {
+        /// Peer pubkey
+        peer_pubkey: String,
+    },
+    /// List peers
+    List,
+}
+
+#[derive(Subcommand)]
+enum PaymentCommands {
+    /// Send a keysend payment
+    Keysend {
+        /// Destination pubkey
+        dest_pubkey: String,
+        /// Amount in msats
+        amt_msat: u64,
+        /// RGB asset ID
+        #[arg(long)]
+        asset_id: Option<String>,
+        /// RGB asset amount
+        #[arg(long)]
+        asset_amount: Option<u64>,
+    },
+    /// Send a payment
+    Send {
+        /// Lightning invoice
+        invoice: String,
+        /// Amount in msats (for zero-amount invoices)
+        #[arg(long)]
+        amt_msat: Option<u64>,
+    },
+    /// Get payment details
+    Get {
+        /// Payment hash
+        payment_hash: String,
+    },
+    /// List payments
+    List,
+}
+
+#[derive(Subcommand)]
+enum InvoiceCommands {
+    /// Create a Lightning invoice
+    LnInvoice {
+        /// Amount in msats
+        amt_msat: u64,
+        /// Expiry in seconds
+        #[arg(long, default_value = "3600")]
+        expiry_sec: u32,
+        /// RGB asset ID
+        #[arg(long)]
+        asset_id: Option<String>,
+        /// RGB asset amount
+        #[arg(long)]
+        asset_amount: Option<u64>,
+    },
+    /// Decode a Lightning invoice
+    DecodeLn {
+        /// Lightning invoice
+        invoice: String,
+    },
+    /// Get invoice status
+    Status {
+        /// Lightning invoice
+        invoice: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum SwapCommands {
+    /// Initialize a maker swap
+    MakerInit {
+        /// Quantity from (taker sends)
+        qty_from: u64,
+        /// Quantity to (taker receives)
+        qty_to: u64,
+        /// From asset ID (taker sends)
+        from_asset: String,
+        /// To asset ID (taker receives)
+        to_asset: String,
+        /// Timeout in seconds
+        #[arg(long, default_value = "300")]
+        timeout_sec: u32,
+    },
+    /// Execute a maker swap
+    MakerExecute {
+        /// Swap string from maker init
+        swapstring: String,
+        /// Payment secret
+        payment_secret: String,
+        /// Taker pubkey
+        taker_pubkey: String,
+    },
+    /// Accept a swap as taker
+    Taker {
+        /// Swap string from maker
+        swapstring: String,
+    },
+    /// Get swap details
+    Get {
+        /// Payment hash
+        payment_hash: String,
+        /// Is taker swap
+        #[arg(long)]
+        taker: bool,
+    },
+    /// List swaps
+    List,
+}
+
+struct ApiClient {
+    client: reqwest::Client,
+    server: String,
+    token: Option<String>,
+    pretty: bool,
+}
+
+impl ApiClient {
+    fn new(server: String, token: Option<String>, pretty: bool) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            server,
+            token,
+            pretty,
+        }
+    }
+
+    async fn get(&self, endpoint: &str) -> ApiResult<Value> {
+        let url = format!("{}{}", self.server, endpoint);
+        let mut req = self.client.get(&url);
+
+        if let Some(token) = &self.token {
+            req = req.header("Authorization", format!("Bearer {}", token));
+        }
+
+        let res = req.send().await?;
+        let status = res.status();
+        let text = res.text().await?;
+
+        if !status.is_success() {
+            return Err(format!("HTTP {}: {}", status, text).into());
+        }
+
+        Ok(serde_json::from_str(&text)?)
+    }
+
+    async fn post<T: serde::Serialize>(&self, endpoint: &str, body: &T) -> ApiResult<Value> {
+        let url = format!("{}{}", self.server, endpoint);
+        let mut req = self.client.post(&url).json(body);
+
+        if let Some(token) = &self.token {
+            req = req.header("Authorization", format!("Bearer {}", token));
+        }
+
+        let res = req.send().await?;
+        let status = res.status();
+        let text = res.text().await?;
+
+        if !status.is_success() {
+            return Err(format!("HTTP {}: {}", status, text).into());
+        }
+
+        Ok(serde_json::from_str(&text)?)
+    }
+
+    async fn post_multipart(&self, endpoint: &str, form: multipart::Form) -> ApiResult<Value> {
+        let url = format!("{}{}", self.server, endpoint);
+        let mut req = self.client.post(&url).multipart(form);
+
+        if let Some(token) = &self.token {
+            req = req.header("Authorization", format!("Bearer {}", token));
+        }
+
+        let res = req.send().await?;
+        let status = res.status();
+        let text = res.text().await?;
+
+        if !status.is_success() {
+            return Err(format!("HTTP {}: {}", status, text).into());
+        }
+
+        Ok(serde_json::from_str(&text)?)
+    }
+
+    fn print(&self, value: &Value) {
+        if self.pretty {
+            println!("{}", serde_json::to_string_pretty(value).unwrap());
+        } else {
+            println!("{}", serde_json::to_string(value).unwrap());
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let client = ApiClient::new(cli.server, cli.token, cli.pretty);
+
+    let result = match cli.command {
+        Commands::Node { command } => handle_node_commands(client, command).await,
+        Commands::Onchain { command } => handle_onchain_commands(client, command).await,
+        Commands::Rgb { command } => handle_rgb_commands(client, command).await,
+        Commands::Channel { command } => handle_channel_commands(client, command).await,
+        Commands::Peer { command } => handle_peer_commands(client, command).await,
+        Commands::Payment { command } => handle_payment_commands(client, command).await,
+        Commands::Invoice { command } => handle_invoice_commands(client, command).await,
+        Commands::Swap { command } => handle_swap_commands(client, command).await,
+    };
+
+    if let Err(e) = result {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+async fn handle_node_commands(client: ApiClient, command: NodeCommands) -> ApiResult<()> {
+    match command {
+        NodeCommands::Init { password } => {
+            let body = serde_json::json!({ "password": password });
+            let res = client.post("/init", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::Unlock {
+            password,
+            bitcoind_rpc_username,
+            bitcoind_rpc_password,
+            bitcoind_rpc_host,
+            bitcoind_rpc_port,
+            indexer_url,
+            proxy_endpoint,
+            announce_addresses,
+            announce_alias,
+        } => {
+            let body = serde_json::json!({
+                "password": password,
+                "bitcoind_rpc_username": bitcoind_rpc_username,
+                "bitcoind_rpc_password": bitcoind_rpc_password,
+                "bitcoind_rpc_host": bitcoind_rpc_host,
+                "bitcoind_rpc_port": bitcoind_rpc_port,
+                "indexer_url": indexer_url,
+                "proxy_endpoint": proxy_endpoint,
+                "announce_addresses": announce_addresses,
+                "announce_alias": announce_alias,
+            });
+            let res = client.post("/unlock", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::Lock => {
+            let res = client.post("/lock", &serde_json::json!({})).await?;
+            client.print(&res);
+        }
+        NodeCommands::Info => {
+            let res = client.get("/nodeinfo").await?;
+            client.print(&res);
+        }
+        NodeCommands::NetworkInfo => {
+            let res = client.get("/networkinfo").await?;
+            client.print(&res);
+        }
+        NodeCommands::Backup {
+            backup_path,
+            password,
+        } => {
+            let body = serde_json::json!({
+                "backup_path": backup_path,
+                "password": password,
+            });
+            let res = client.post("/backup", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::Restore {
+            backup_path,
+            password,
+        } => {
+            let body = serde_json::json!({
+                "backup_path": backup_path,
+                "password": password,
+            });
+            let res = client.post("/restore", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::ChangePassword {
+            old_password,
+            new_password,
+        } => {
+            let body = serde_json::json!({
+                "old_password": old_password,
+                "new_password": new_password,
+            });
+            let res = client.post("/changepassword", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::CheckIndexer { indexer_url } => {
+            let body = serde_json::json!({ "indexer_url": indexer_url });
+            let res = client.post("/checkindexerurl", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::CheckProxy { proxy_url } => {
+            let body = serde_json::json!({ "proxy_endpoint": proxy_url });
+            let res = client.post("/checkproxyendpoint", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::RevokeToken { token } => {
+            let body = serde_json::json!({ "token": token });
+            let res = client.post("/revoketoken", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::SendOnionMessage {
+            node_ids,
+            tlv_type,
+            data,
+        } => {
+            let body = serde_json::json!({
+                "node_ids": node_ids,
+                "tlv_type": tlv_type,
+                "data": data,
+            });
+            let res = client.post("/sendonionmessage", &body).await?;
+            client.print(&res);
+        }
+        NodeCommands::Shutdown => {
+            let res = client.post("/shutdown", &serde_json::json!({})).await?;
+            client.print(&res);
+        }
+        NodeCommands::SignMessage { message } => {
+            let body = serde_json::json!({ "message": message });
+            let res = client.post("/signmessage", &body).await?;
+            client.print(&res);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_onchain_commands(client: ApiClient, command: OnchainCommands) -> ApiResult<()> {
+    match command {
+        OnchainCommands::Address => {
+            let res = client.post("/address", &serde_json::json!({})).await?;
+            client.print(&res);
+        }
+        OnchainCommands::BtcBalance { skip_sync } => {
+            let body = serde_json::json!({ "skip_sync": skip_sync });
+            let res = client.post("/btcbalance", &body).await?;
+            client.print(&res);
+        }
+        OnchainCommands::EstimateFee { blocks } => {
+            let body = serde_json::json!({ "blocks": blocks });
+            let res = client.post("/estimatefee", &body).await?;
+            client.print(&res);
+        }
+        OnchainCommands::ListTransactions { skip_sync } => {
+            let body = serde_json::json!({ "skip_sync": skip_sync });
+            let res = client.post("/listtransactions", &body).await?;
+            client.print(&res);
+        }
+        OnchainCommands::ListUnspents { skip_sync } => {
+            let body = serde_json::json!({ "skip_sync": skip_sync });
+            let res = client.post("/listunspents", &body).await?;
+            client.print(&res);
+        }
+        OnchainCommands::SendBtc {
+            amount,
+            address,
+            fee_rate,
+            skip_sync,
+        } => {
+            let body = serde_json::json!({
+                "amount": amount,
+                "address": address,
+                "fee_rate": fee_rate,
+                "skip_sync": skip_sync,
+            });
+            let res = client.post("/sendbtc", &body).await?;
+            client.print(&res);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_rgb_commands(client: ApiClient, command: RgbCommands) -> ApiResult<()> {
+    match command {
+        RgbCommands::AssetBalance { asset_id } => {
+            let body = serde_json::json!({ "asset_id": asset_id });
+            let res = client.post("/assetbalance", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::AssetMetadata { asset_id } => {
+            let body = serde_json::json!({ "asset_id": asset_id });
+            let res = client.post("/assetmetadata", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::CreateUtxos {
+            up_to,
+            num,
+            size,
+            fee_rate,
+            skip_sync,
+        } => {
+            let body = serde_json::json!({
+                "up_to": up_to,
+                "num": num,
+                "size": size,
+                "fee_rate": fee_rate,
+                "skip_sync": skip_sync,
+            });
+            let res = client.post("/createutxos", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::DecodeInvoice { invoice } => {
+            let body = serde_json::json!({ "invoice": invoice });
+            let res = client.post("/decodergbinvoice", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::FailTransfers {
+            batch_transfer_idx,
+            no_asset_only,
+            skip_sync,
+        } => {
+            let body = serde_json::json!({
+                "batch_transfer_idx": batch_transfer_idx,
+                "no_asset_only": no_asset_only,
+                "skip_sync": skip_sync,
+            });
+            let res = client.post("/failtransfers", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::GetMedia { digest } => {
+            let body = serde_json::json!({ "digest": digest });
+            let res = client.post("/getassetmedia", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::IssueCfa {
+            amounts,
+            name,
+            details,
+            precision,
+            file_digest,
+        } => {
+            let body = serde_json::json!({
+                "amounts": amounts,
+                "name": name,
+                "details": details,
+                "precision": precision,
+                "file_digest": file_digest,
+            });
+            let res = client.post("/issueassetcfa", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::IssueNia {
+            amounts,
+            ticker,
+            name,
+            precision,
+        } => {
+            let body = serde_json::json!({
+                "amounts": amounts,
+                "ticker": ticker,
+                "name": name,
+                "precision": precision,
+            });
+            let res = client.post("/issueassetnia", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::IssueUda {
+            ticker,
+            name,
+            details,
+            precision,
+            media_file_digest,
+            attachments_file_digests,
+        } => {
+            let body = serde_json::json!({
+                "ticker": ticker,
+                "name": name,
+                "details": details,
+                "precision": precision,
+                "media_file_digest": media_file_digest,
+                "attachments_file_digests": attachments_file_digests,
+            });
+            let res = client.post("/issueassetuda", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::ListAssets { filter_schemas } => {
+            let schemas: Vec<String> = if filter_schemas.is_empty() {
+                vec!["Nia".to_string(), "Uda".to_string(), "Cfa".to_string()]
+            } else {
+                filter_schemas
+            };
+            let body = serde_json::json!({ "filter_asset_schemas": schemas });
+            let res = client.post("/listassets", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::ListTransfers { asset_id } => {
+            let body = serde_json::json!({ "asset_id": asset_id });
+            let res = client.post("/listtransfers", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::PostMedia { file_path } => {
+            let file_bytes = std::fs::read(&file_path)?;
+            let file_name = std::path::Path::new(&file_path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("file");
+
+            let part = multipart::Part::bytes(file_bytes).file_name(file_name.to_string());
+
+            let form = multipart::Form::new().part("file", part);
+            let res = client.post_multipart("/postassetmedia", form).await?;
+            client.print(&res);
+        }
+        RgbCommands::RefreshTransfers { skip_sync } => {
+            let body = serde_json::json!({ "skip_sync": skip_sync });
+            let res = client.post("/refreshtransfers", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::RgbInvoice {
+            asset_id,
+            amount,
+            duration_seconds,
+            min_confirmations,
+            witness,
+        } => {
+            let assignment = if let Some(amt) = amount {
+                serde_json::json!({
+                    "type": "Fungible",
+                    "value": amt
+                })
+            } else {
+                serde_json::json!({
+                    "type": "Any"
+                })
+            };
+
+            let body = serde_json::json!({
+                "asset_id": asset_id,
+                "assignment": assignment,
+                "duration_seconds": duration_seconds,
+                "min_confirmations": min_confirmations,
+                "witness": witness,
+            });
+            let res = client.post("/rgbinvoice", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::SendAsset {
+            asset_id,
+            amount,
+            recipient_id,
+            donation,
+            fee_rate,
+            min_confirmations,
+            transport_endpoints,
+            skip_sync,
+        } => {
+            let body = serde_json::json!({
+                "asset_id": asset_id,
+                "assignment": {
+                    "type": "Fungible",
+                    "value": amount
+                },
+                "recipient_id": recipient_id,
+                "witness_data": null,
+                "donation": donation,
+                "fee_rate": fee_rate,
+                "min_confirmations": min_confirmations,
+                "transport_endpoints": transport_endpoints,
+                "skip_sync": skip_sync,
+            });
+            let res = client.post("/sendasset", &body).await?;
+            client.print(&res);
+        }
+        RgbCommands::Sync => {
+            let res = client.post("/sync", &serde_json::json!({})).await?;
+            client.print(&res);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_channel_commands(client: ApiClient, command: ChannelCommands) -> ApiResult<()> {
+    match command {
+        ChannelCommands::Open {
+            peer,
+            capacity_sat,
+            push_msat,
+            asset_amount,
+            asset_id,
+            public,
+            with_anchors,
+            fee_base_msat,
+            fee_proportional_millionths,
+            temporary_channel_id,
+        } => {
+            let body = serde_json::json!({
+                "peer_pubkey_and_opt_addr": peer,
+                "capacity_sat": capacity_sat,
+                "push_msat": push_msat,
+                "asset_amount": asset_amount,
+                "asset_id": asset_id,
+                "public": public,
+                "with_anchors": with_anchors,
+                "fee_base_msat": fee_base_msat,
+                "fee_proportional_millionths": fee_proportional_millionths,
+                "temporary_channel_id": temporary_channel_id,
+            });
+            let res = client.post("/openchannel", &body).await?;
+            client.print(&res);
+        }
+        ChannelCommands::Close {
+            channel_id,
+            peer_pubkey,
+            force,
+        } => {
+            let body = serde_json::json!({
+                "channel_id": channel_id,
+                "peer_pubkey": peer_pubkey,
+                "force": force,
+            });
+            let res = client.post("/closechannel", &body).await?;
+            client.print(&res);
+        }
+        ChannelCommands::GetId {
+            temporary_channel_id,
+        } => {
+            let body = serde_json::json!({ "temporary_channel_id": temporary_channel_id });
+            let res = client.post("/getchannelid", &body).await?;
+            client.print(&res);
+        }
+        ChannelCommands::List => {
+            let res = client.get("/listchannels").await?;
+            client.print(&res);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_peer_commands(client: ApiClient, command: PeerCommands) -> ApiResult<()> {
+    match command {
+        PeerCommands::Connect {
+            peer_pubkey_and_addr,
+        } => {
+            let body = serde_json::json!({ "peer_pubkey_and_addr": peer_pubkey_and_addr });
+            let res = client.post("/connectpeer", &body).await?;
+            client.print(&res);
+        }
+        PeerCommands::Disconnect { peer_pubkey } => {
+            let body = serde_json::json!({ "peer_pubkey": peer_pubkey });
+            let res = client.post("/disconnectpeer", &body).await?;
+            client.print(&res);
+        }
+        PeerCommands::List => {
+            let res = client.get("/listpeers").await?;
+            client.print(&res);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_payment_commands(client: ApiClient, command: PaymentCommands) -> ApiResult<()> {
+    match command {
+        PaymentCommands::Keysend {
+            dest_pubkey,
+            amt_msat,
+            asset_id,
+            asset_amount,
+        } => {
+            let body = serde_json::json!({
+                "dest_pubkey": dest_pubkey,
+                "amt_msat": amt_msat,
+                "asset_id": asset_id,
+                "asset_amount": asset_amount,
+            });
+            let res = client.post("/keysend", &body).await?;
+            client.print(&res);
+        }
+        PaymentCommands::Send { invoice, amt_msat } => {
+            let body = serde_json::json!({
+                "invoice": invoice,
+                "amt_msat": amt_msat,
+            });
+            let res = client.post("/sendpayment", &body).await?;
+            client.print(&res);
+        }
+        PaymentCommands::Get { payment_hash } => {
+            let body = serde_json::json!({ "payment_hash": payment_hash });
+            let res = client.post("/getpayment", &body).await?;
+            client.print(&res);
+        }
+        PaymentCommands::List => {
+            let res = client.get("/listpayments").await?;
+            client.print(&res);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_invoice_commands(client: ApiClient, command: InvoiceCommands) -> ApiResult<()> {
+    match command {
+        InvoiceCommands::LnInvoice {
+            amt_msat,
+            expiry_sec,
+            asset_id,
+            asset_amount,
+        } => {
+            let body = serde_json::json!({
+                "amt_msat": amt_msat,
+                "expiry_sec": expiry_sec,
+                "asset_id": asset_id,
+                "asset_amount": asset_amount,
+            });
+            let res = client.post("/lninvoice", &body).await?;
+            client.print(&res);
+        }
+        InvoiceCommands::DecodeLn { invoice } => {
+            let body = serde_json::json!({ "invoice": invoice });
+            let res = client.post("/decodelninvoice", &body).await?;
+            client.print(&res);
+        }
+        InvoiceCommands::Status { invoice } => {
+            let body = serde_json::json!({ "invoice": invoice });
+            let res = client.post("/invoicestatus", &body).await?;
+            client.print(&res);
+        }
+    }
+    Ok(())
+}
+
+async fn handle_swap_commands(client: ApiClient, command: SwapCommands) -> ApiResult<()> {
+    match command {
+        SwapCommands::MakerInit {
+            qty_from,
+            qty_to,
+            from_asset,
+            to_asset,
+            timeout_sec,
+        } => {
+            let from_asset = if from_asset.to_lowercase() == "btc" {
+                None
+            } else {
+                Some(from_asset)
+            };
+            let to_asset = if to_asset.to_lowercase() == "btc" {
+                None
+            } else {
+                Some(to_asset)
+            };
+
+            let body = serde_json::json!({
+                "qty_from": qty_from,
+                "qty_to": qty_to,
+                "from_asset": from_asset,
+                "to_asset": to_asset,
+                "timeout_sec": timeout_sec,
+            });
+            let res = client.post("/makerinit", &body).await?;
+            client.print(&res);
+        }
+        SwapCommands::MakerExecute {
+            swapstring,
+            payment_secret,
+            taker_pubkey,
+        } => {
+            let body = serde_json::json!({
+                "swapstring": swapstring,
+                "payment_secret": payment_secret,
+                "taker_pubkey": taker_pubkey,
+            });
+            let res = client.post("/makerexecute", &body).await?;
+            client.print(&res);
+        }
+        SwapCommands::Taker { swapstring } => {
+            let body = serde_json::json!({ "swapstring": swapstring });
+            let res = client.post("/taker", &body).await?;
+            client.print(&res);
+        }
+        SwapCommands::Get {
+            payment_hash,
+            taker,
+        } => {
+            let body = serde_json::json!({
+                "payment_hash": payment_hash,
+                "taker": taker,
+            });
+            let res = client.post("/getswap", &body).await?;
+            client.print(&res);
+        }
+        SwapCommands::List => {
+            let res = client.get("/listswaps").await?;
+            client.print(&res);
+        }
+    }
+    Ok(())
+}

--- a/src/test/cli_integration.rs
+++ b/src/test/cli_integration.rs
@@ -1,0 +1,714 @@
+use super::*;
+use std::process::{Command, Stdio};
+
+const TEST_DIR_BASE: &str = "tmp/cli_integration/";
+
+// Helper function to run CLI commands
+fn run_cli_command(
+    server_url: &str,
+    token: Option<&str>,
+    args: &[&str],
+) -> Result<serde_json::Value, String> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run")
+        .arg("--bin")
+        .arg("rln-cli")
+        .arg("--")
+        .arg("--server")
+        .arg(server_url);
+
+    if let Some(t) = token {
+        cmd.arg("--token").arg(t);
+    }
+
+    for arg in args {
+        cmd.arg(arg);
+    }
+
+    let output = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("Failed to execute CLI: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("CLI command failed: {}", stderr));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).map_err(|e| format!("Failed to parse JSON: {}", e))
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_node_info() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Test node info command
+    let result = run_cli_command(&server_url, None, &["node", "info"]);
+    assert!(result.is_ok(), "CLI node info failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("pubkey").is_some());
+    assert!(json.get("num_peers").is_some());
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_network_info() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_network");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Test network info command
+    let result = run_cli_command(&server_url, None, &["node", "network-info"]);
+    assert!(result.is_ok(), "CLI network info failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("network").is_some());
+    assert_eq!(json["network"], "Regtest");
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_onchain_address() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_address");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Test address command
+    let result = run_cli_command(&server_url, None, &["onchain", "address"]);
+    assert!(result.is_ok(), "CLI address failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("address").is_some());
+    let address = json["address"].as_str().unwrap();
+    assert!(address.starts_with("bcrt1"));
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_onchain_btc_balance() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_btc_balance");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund the node first
+    fund_and_create_utxos(node1_addr, None).await;
+
+    // Test btc-balance command
+    let result = run_cli_command(&server_url, None, &["onchain", "btc-balance"]);
+    assert!(result.is_ok(), "CLI btc-balance failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("vanilla").is_some());
+    assert!(json.get("colored").is_some());
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_rgb_issue_nia() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_issue_nia");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund the node
+    fund_and_create_utxos(node1_addr, None).await;
+
+    // Test issue-nia command
+    let result = run_cli_command(
+        &server_url,
+        None,
+        &[
+            "rgb",
+            "issue-nia",
+            "--amounts",
+            "1000",
+            "USDT",
+            "Tether USD",
+            "--precision",
+            "8",
+        ],
+    );
+    assert!(result.is_ok(), "CLI issue-nia failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("asset").is_some());
+    assert!(json["asset"].get("asset_id").is_some());
+    let asset_id = json["asset"]["asset_id"].as_str().unwrap();
+    assert!(!asset_id.is_empty());
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_rgb_list_assets() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_list_assets");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund and issue an asset
+    fund_and_create_utxos(node1_addr, None).await;
+    let asset_nia = issue_asset_nia(node1_addr).await;
+
+    // Test list-assets command
+    let result = run_cli_command(&server_url, None, &["rgb", "list-assets"]);
+    assert!(result.is_ok(), "CLI list-assets failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("nia").is_some());
+    let nia_assets = json["nia"].as_array().unwrap();
+    assert_eq!(nia_assets.len(), 1);
+    assert_eq!(nia_assets[0]["asset_id"], asset_nia.asset_id);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_rgb_asset_balance() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_asset_balance");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund and issue an asset
+    fund_and_create_utxos(node1_addr, None).await;
+    let asset_nia = issue_asset_nia(node1_addr).await;
+
+    // Test asset-balance command
+    let result = run_cli_command(
+        &server_url,
+        None,
+        &["rgb", "asset-balance", &asset_nia.asset_id],
+    );
+    assert!(result.is_ok(), "CLI asset-balance failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("spendable").is_some());
+    assert_eq!(json["spendable"], 1000);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_peer_connect_list_disconnect() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_peer");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2_peer");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Get node2 info for connection
+    let node2_info = node_info(node2_addr).await;
+    let node2_pubkey = node2_info.pubkey;
+    let peer_addr = format!("{}@127.0.0.1:{}", node2_pubkey, NODE2_PEER_PORT);
+
+    // Test peer connect command
+    let result = run_cli_command(&server_url, None, &["peer", "connect", &peer_addr]);
+    assert!(result.is_ok(), "CLI peer connect failed: {:?}", result);
+
+    // Wait a bit for connection to establish
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Test peer list command
+    let result = run_cli_command(&server_url, None, &["peer", "list"]);
+    assert!(result.is_ok(), "CLI peer list failed: {:?}", result);
+
+    let json = result.unwrap();
+    let peers = json["peers"].as_array().unwrap();
+    assert_eq!(peers.len(), 1);
+    assert_eq!(peers[0]["pubkey"], node2_pubkey);
+
+    // Test peer disconnect command
+    let result = run_cli_command(&server_url, None, &["peer", "disconnect", &node2_pubkey]);
+    assert!(result.is_ok(), "CLI peer disconnect failed: {:?}", result);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_channel_open_list() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_channel");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2_channel");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund both nodes
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    // Get node2 info
+    let node2_info = node_info(node2_addr).await;
+    let node2_pubkey = node2_info.pubkey;
+    let peer_addr = format!("{}@127.0.0.1:{}", node2_pubkey, NODE2_PEER_PORT);
+
+    // Test channel open command
+    let result = run_cli_command(
+        &server_url,
+        None,
+        &["channel", "open", &peer_addr, "100000"],
+    );
+    assert!(result.is_ok(), "CLI channel open failed: {:?}", result);
+
+    // Mine blocks to confirm channel
+    mine(false);
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    // Test channel list command
+    let result = run_cli_command(&server_url, None, &["channel", "list"]);
+    assert!(result.is_ok(), "CLI channel list failed: {:?}", result);
+
+    let json = result.unwrap();
+    let channels = json["channels"].as_array().unwrap();
+    assert_eq!(channels.len(), 1);
+    assert_eq!(channels[0]["peer_pubkey"], node2_pubkey);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_invoice_create_decode() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_invoice");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Test ln-invoice command
+    let result = run_cli_command(&server_url, None, &["invoice", "ln-invoice", "10000"]);
+    assert!(result.is_ok(), "CLI ln-invoice failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("invoice").is_some());
+    let invoice = json["invoice"].as_str().unwrap();
+    assert!(invoice.starts_with("lnbc"));
+
+    // Test decode-ln command
+    let result = run_cli_command(&server_url, None, &["invoice", "decode-ln", invoice]);
+    assert!(result.is_ok(), "CLI decode-ln failed: {:?}", result);
+
+    let decoded = result.unwrap();
+    assert!(decoded.get("payment_hash").is_some());
+    assert_eq!(decoded["amt_msat"], 10000);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_rgb_invoice_create_decode() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_rgb_invoice");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund and issue an asset
+    fund_and_create_utxos(node1_addr, None).await;
+    let asset_nia = issue_asset_nia(node1_addr).await;
+
+    // Test rgb-invoice command
+    let result = run_cli_command(
+        &server_url,
+        None,
+        &["rgb", "rgb-invoice", &asset_nia.asset_id, "--amount", "100"],
+    );
+    assert!(result.is_ok(), "CLI rgb-invoice failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("invoice").is_some());
+    let invoice = json["invoice"].as_str().unwrap();
+    assert!(!invoice.is_empty());
+
+    // Test decode-invoice command
+    let result = run_cli_command(&server_url, None, &["rgb", "decode-invoice", invoice]);
+    assert!(result.is_ok(), "CLI decode-invoice failed: {:?}", result);
+
+    let decoded = result.unwrap();
+    assert_eq!(decoded["asset_id"], asset_nia.asset_id);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_payment_keysend() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_keysend");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2_keysend");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund both nodes
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    // Open channel
+    let node2_info = node_info(node2_addr).await;
+    let node2_pubkey = node2_info.pubkey.clone();
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(100000),
+        Some(0),
+        None,
+        None,
+    )
+    .await;
+
+    // Test keysend command (minimum amount is 3000000 msats)
+    let result = run_cli_command(
+        &server_url,
+        None,
+        &["payment", "keysend", &node2_pubkey, "3000000"],
+    );
+    assert!(result.is_ok(), "CLI keysend failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("payment_hash").is_some());
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_payment_list() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_payment_list");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Test payment list command (should be empty initially)
+    let result = run_cli_command(&server_url, None, &["payment", "list"]);
+    assert!(result.is_ok(), "CLI payment list failed: {:?}", result);
+
+    let json = result.unwrap();
+    let payments = json["payments"].as_array().unwrap();
+    assert_eq!(payments.len(), 0);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_swap_maker_init() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_swap");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2_swap");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    let server_url_1 = format!("http://{}", node1_addr);
+    let server_url_2 = format!("http://{}", node2_addr);
+
+    // Fund both nodes and create UTXOs
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    // Issue asset on node1
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+
+    let node1_pubkey = node_info(node1_addr).await.pubkey;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    // Open RGB channel from node1 to node2 with asset (600 units)
+    let _channel_12 = open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        Some(600),
+        Some(&asset_id),
+    )
+    .await;
+
+    // Open BTC channel from node2 to node1 (for swap payment)
+    let _channel_21 = open_channel(
+        node2_addr,
+        &node1_pubkey,
+        Some(NODE1_PEER_PORT),
+        Some(5000000),
+        Some(546000),
+        None,
+        None,
+    )
+    .await;
+
+    wait_for_usable_channels(node1_addr, 2).await;
+    wait_for_usable_channels(node2_addr, 2).await;
+
+    // Setup swap parameters
+    let qty_from = 50000; // BTC msats
+    let qty_to = 10; // RGB asset units
+
+    // Test maker-init command via CLI (node1 initiates swap: receives BTC, sends asset)
+    let result = run_cli_command(
+        &server_url_1,
+        None,
+        &[
+            "swap",
+            "maker-init",
+            &qty_from.to_string(),
+            &qty_to.to_string(),
+            "btc",     // from_asset (taker sends BTC)
+            &asset_id, // to_asset (taker receives asset)
+            "--timeout-sec",
+            "3600",
+        ],
+    );
+    assert!(result.is_ok(), "CLI maker-init failed: {:?}", result);
+
+    let maker_init_json = result.unwrap();
+    assert!(maker_init_json.get("swapstring").is_some());
+    assert!(maker_init_json.get("payment_hash").is_some());
+    assert!(maker_init_json.get("payment_secret").is_some());
+
+    let swapstring = maker_init_json["swapstring"].as_str().unwrap();
+    let payment_hash = maker_init_json["payment_hash"].as_str().unwrap();
+    let payment_secret = maker_init_json["payment_secret"].as_str().unwrap();
+
+    // Test swap list on maker (should show 1 maker swap)
+    let result = run_cli_command(&server_url_1, None, &["swap", "list"]);
+    assert!(result.is_ok(), "CLI swap list failed: {:?}", result);
+    let json = result.unwrap();
+    assert_eq!(json["maker"].as_array().unwrap().len(), 1);
+    assert_eq!(json["taker"].as_array().unwrap().len(), 0);
+
+    // Test taker command via CLI (node2 accepts swap)
+    let result = run_cli_command(&server_url_2, None, &["swap", "taker", swapstring]);
+    assert!(result.is_ok(), "CLI taker failed: {:?}", result);
+
+    // Test swap list on taker (should show 1 taker swap)
+    let result = run_cli_command(&server_url_2, None, &["swap", "list"]);
+    assert!(result.is_ok(), "CLI swap list failed: {:?}", result);
+    let json = result.unwrap();
+    assert_eq!(json["maker"].as_array().unwrap().len(), 0);
+    assert_eq!(json["taker"].as_array().unwrap().len(), 1);
+
+    // Test maker-execute command via CLI (node1 executes swap)
+    let result = run_cli_command(
+        &server_url_1,
+        None,
+        &[
+            "swap",
+            "maker-execute",
+            swapstring,
+            payment_secret,
+            &node2_pubkey,
+        ],
+    );
+    assert!(result.is_ok(), "CLI maker-execute failed: {:?}", result);
+
+    // Wait for swap to complete
+    wait_for_swap_status(node1_addr, payment_hash, SwapStatus::Succeeded).await;
+    wait_for_swap_status(node2_addr, payment_hash, SwapStatus::Succeeded).await;
+
+    // Verify final balances
+    wait_for_ln_balance(node1_addr, &asset_id, 590).await; // 600 - 10 = 590
+    wait_for_ln_balance(node2_addr, &asset_id, 10).await; // 0 + 10 = 10
+
+    // Test get swap command via CLI (from maker's perspective, no --taker flag)
+    let result = run_cli_command(&server_url_1, None, &["swap", "get", payment_hash]);
+    assert!(result.is_ok(), "CLI swap get failed: {:?}", result);
+    let swap_response = result.unwrap();
+    assert!(swap_response.get("swap").is_some());
+    let swap_json = &swap_response["swap"];
+    assert_eq!(swap_json["status"], "Succeeded");
+    assert_eq!(swap_json["qty_from"], qty_from);
+    assert_eq!(swap_json["qty_to"], qty_to);
+
+    // Test get swap command from taker's perspective (with --taker flag)
+    let result = run_cli_command(
+        &server_url_2,
+        None,
+        &["swap", "get", payment_hash, "--taker"],
+    );
+    assert!(result.is_ok(), "CLI swap get (taker) failed: {:?}", result);
+    let taker_swap_response = result.unwrap();
+    assert!(taker_swap_response.get("swap").is_some());
+    let taker_swap_json = &taker_swap_response["swap"];
+    assert_eq!(taker_swap_json["status"], "Succeeded");
+    assert_eq!(taker_swap_json["qty_from"], qty_from);
+    assert_eq!(taker_swap_json["qty_to"], qty_to);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_swap_list() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_swap_list");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Test swap list command (should be empty initially)
+    let result = run_cli_command(&server_url, None, &["swap", "list"]);
+    assert!(result.is_ok(), "CLI swap list failed: {:?}", result);
+
+    let json = result.unwrap();
+    assert!(json.get("maker").is_some());
+    assert!(json.get("taker").is_some());
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_onchain_list_transactions() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_list_tx");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund the node to create transactions
+    fund_and_create_utxos(node1_addr, None).await;
+
+    // Test list-transactions command
+    let result = run_cli_command(&server_url, None, &["onchain", "list-transactions"]);
+    assert!(result.is_ok(), "CLI list-transactions failed: {:?}", result);
+
+    let json = result.unwrap();
+    let transactions = json["transactions"].as_array().unwrap();
+    assert!(!transactions.is_empty());
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_onchain_list_unspents() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_list_unspents");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund the node to create UTXOs
+    fund_and_create_utxos(node1_addr, None).await;
+
+    // Test list-unspents command
+    let result = run_cli_command(&server_url, None, &["onchain", "list-unspents"]);
+    assert!(result.is_ok(), "CLI list-unspents failed: {:?}", result);
+
+    let json = result.unwrap();
+    let unspents = json["unspents"].as_array().unwrap();
+    assert!(!unspents.is_empty());
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_rgb_create_utxos() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_create_utxos");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Fund the node
+    fund_and_create_utxos(node1_addr, None).await;
+
+    let unspents_before = list_unspents(node1_addr).await;
+
+    // Test create-utxos command
+    let result = run_cli_command(
+        &server_url,
+        None,
+        &["rgb", "create-utxos", "3", "5000", "1"],
+    );
+    assert!(result.is_ok(), "CLI create-utxos failed: {:?}", result);
+
+    // Wait for transaction to be processed
+    mine(false);
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let unspents_after = list_unspents(node1_addr).await;
+    assert!(unspents_after.len() >= unspents_before.len() + 3);
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_with_custom_server_url() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_custom_url");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Test that custom server URL works
+    let result = run_cli_command(&server_url, None, &["node", "info"]);
+    assert!(
+        result.is_ok(),
+        "CLI with custom server URL failed: {:?}",
+        result
+    );
+}
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn cli_error_handling_invalid_command() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1_invalid");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+
+    let server_url = format!("http://{}", node1_addr);
+
+    // Test that invalid asset ID returns error appropriately
+    let result = run_cli_command(
+        &server_url,
+        None,
+        &["rgb", "asset-balance", "invalid_asset_id"],
+    );
+
+    // This should fail gracefully
+    assert!(result.is_err() || result.unwrap().get("error").is_some());
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1794,6 +1794,7 @@ pub fn mock_fee(fee: u32) -> u32 {
 
 mod authentication;
 mod backup_and_restore;
+mod cli_integration;
 mod close_coop_nobtc_acceptor;
 mod close_coop_other_side;
 mod close_coop_standard;


### PR DESCRIPTION
This PR introduces a command-line interface (CLI) for the RGB Lightning Node and adds Makefile support for streamlined development workflows.
It addresses **#83**.

### Summary of Changes

* **Introduced `rln-cli`** as a new binary for interacting with the RGB Lightning Node.
* **Added a `Makefile`** with targets for building, testing, and running both the CLI and node.
* **Updated `Cargo.toml`** to include the new `rln-cli` package and required dependencies.
* **Enhanced `README.md`** with CLI usage examples, setup instructions, and common commands.
* **Added a demo script** to showcase typical CLI operations.
* **Implemented integration tests** for key CLI commands to ensure reliable functionality.