### PR TITLE
Fix private-channel swap routing

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -2812,6 +2812,7 @@ pub(crate) async fn maker_execute(
         let first_leg = get_route(
             &unlocked_state.channel_manager,
             &unlocked_state.router,
+            &state.static_state.ldk_data_dir,
             unlocked_state.channel_manager.get_our_node_id(),
             taker_pk,
             if swap_info.is_to_btc() {
@@ -2829,6 +2830,7 @@ pub(crate) async fn maker_execute(
         let second_leg = get_route(
             &unlocked_state.channel_manager,
             &unlocked_state.router,
+            &state.static_state.ldk_data_dir,
             taker_pk,
             unlocked_state.channel_manager.get_our_node_id(),
             if swap_info.is_to_btc() || swap_info.is_asset_asset() {

--- a/src/test/drop_funding_signed.rs
+++ b/src/test/drop_funding_signed.rs
@@ -41,6 +41,7 @@ async fn drop_funding_signed() {
         None,
         None,
         true,
+        true,
     )
     .await
     .unwrap();
@@ -93,6 +94,7 @@ async fn drop_funding_signed() {
         None,
         None,
         None,
+        true,
         true,
     )
     .await

--- a/src/test/missing_acceptor.rs
+++ b/src/test/missing_acceptor.rs
@@ -42,6 +42,7 @@ async fn missing_acceptor() {
         None,
         None,
         true,
+        true,
     )
     .await
     .unwrap();

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1222,6 +1222,7 @@ async fn open_channel_with_retry(
             None,
             None,
             true,
+            true,
         )
         .await;
 
@@ -1259,6 +1260,7 @@ async fn open_channel_funded_raw(
     fee_proportional_millionths: Option<u32>,
     temporary_channel_id: Option<&str>,
     with_anchors: bool,
+    public: bool,
 ) -> Result<Channel, Response> {
     open_channel_raw(
         node_address,
@@ -1273,6 +1275,7 @@ async fn open_channel_funded_raw(
         fee_proportional_millionths,
         temporary_channel_id,
         with_anchors,
+        public,
     )
     .await?;
 
@@ -1352,6 +1355,7 @@ async fn open_channel_raw(
     fee_proportional_millionths: Option<u32>,
     temporary_channel_id: Option<&str>,
     with_anchors: bool,
+    public: bool,
 ) -> Result<OpenChannelResponse, Response> {
     println!(
         "opening channel with {asset_amount:?} of asset {asset_id:?} from node {node_address} \
@@ -1383,7 +1387,7 @@ async fn open_channel_raw(
         asset_amount,
         asset_id: asset_id.map(|a| a.to_string()),
         push_asset_amount,
-        public: true,
+        public,
         with_anchors,
         fee_base_msat,
         fee_proportional_millionths,
@@ -1432,6 +1436,7 @@ async fn open_channel_with_custom_data(
         fee_proportional_millionths,
         temporary_channel_id,
         with_anchors,
+        true,
     )
     .await
     .expect("channel opening should succeed")

--- a/src/test/openchannel_fail.rs
+++ b/src/test/openchannel_fail.rs
@@ -35,6 +35,7 @@ async fn openchannel_fail() {
         None,
         None,
         true,
+        true,
     )
     .await;
     check_response_is_nok(
@@ -65,6 +66,7 @@ async fn openchannel_fail() {
         None,
         None,
         true,
+        true,
     )
     .await;
     check_response_is_nok(
@@ -94,6 +96,7 @@ async fn openchannel_fail() {
         None,
         None,
         None,
+        true,
         true,
     )
     .await;

--- a/src/test/openchannel_no_indexer.rs
+++ b/src/test/openchannel_no_indexer.rs
@@ -36,6 +36,7 @@ async fn openchannel_no_indexer() {
         None,
         None,
         true,
+        true,
     )
     .await;
 

--- a/src/test/swap_reverse_same_channel.rs
+++ b/src/test/swap_reverse_same_channel.rs
@@ -186,4 +186,66 @@ async fn swap_reverse_same_channel() {
     assert_eq!(swaps_taker.taker.len(), 1);
     let swap_taker = swaps_taker.taker.first().unwrap();
     assert_eq!(swap_taker.status, SwapStatus::Succeeded);
+
+    let private_asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    open_channel_funded_raw(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(100000),
+        Some(50000000),
+        Some(100),
+        Some(&private_asset_id),
+        None,
+        None,
+        None,
+        None,
+        true,
+        false,
+    )
+    .await
+    .expect("private channel opening should succeed");
+
+    println!("\nsetup private channel swap");
+    let maker_addr = node1_addr;
+    let taker_addr = node2_addr;
+    let qty_from = 25000;
+    let qty_to = 10;
+    let maker_init_response = maker_init(
+        maker_addr,
+        qty_from,
+        None,
+        qty_to,
+        Some(&private_asset_id),
+        3600,
+    )
+    .await;
+    taker(taker_addr, maker_init_response.swapstring.clone()).await;
+
+    println!("\nexecute private channel swap");
+    maker_execute(
+        maker_addr,
+        maker_init_response.swapstring,
+        maker_init_response.payment_secret,
+        node2_pubkey,
+    )
+    .await;
+
+    let swaps_maker = list_swaps(maker_addr).await;
+    assert_eq!(swaps_maker.maker.len(), 2);
+    let swap_maker = swaps_maker
+        .maker
+        .iter()
+        .find(|s| s.payment_hash == maker_init_response.payment_hash)
+        .unwrap();
+    assert_eq!(swap_maker.status, SwapStatus::Pending);
+    wait_for_swap_status(
+        taker_addr,
+        &maker_init_response.payment_hash,
+        SwapStatus::Pending,
+    )
+    .await;
+
+    wait_for_ln_balance(maker_addr, &private_asset_id, 90).await;
+    wait_for_ln_balance(taker_addr, &private_asset_id, 10).await;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -405,9 +405,11 @@ pub(crate) fn get_max_local_rgb_amount<'r>(
     max_balance
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn get_route(
     channel_manager: &crate::ldk::ChannelManager,
     router: &crate::ldk::Router,
+    ldk_data_dir_path: &Path,
     start: PublicKey,
     dest: PublicKey,
     final_value_msat: Option<u64>,
@@ -415,6 +417,23 @@ pub(crate) fn get_route(
     hints: Vec<RouteHint>,
 ) -> Option<Route> {
     let inflight_htlcs = channel_manager.compute_inflight_htlcs();
+    let usable_channels;
+    let first_hops = if start == channel_manager.get_our_node_id() {
+        usable_channels = channel_manager.list_usable_channels();
+        let first_hops = usable_channels
+            .iter()
+            .filter(|channel| match rgb_payment {
+                Some((contract_id, _)) => {
+                    get_rgb_channel_info_optional(&channel.channel_id, ldk_data_dir_path, false)
+                        .is_some_and(|(rgb_info, _)| rgb_info.contract_id == contract_id)
+                }
+                None => true,
+            })
+            .collect::<Vec<_>>();
+        (!first_hops.is_empty()).then_some(first_hops)
+    } else {
+        None
+    };
     let payment_params = PaymentParameters {
         payee: Payee::Clear {
             node_id: dest,
@@ -438,7 +457,7 @@ pub(crate) fn get_route(
             max_total_routing_fee_msat: None,
             rgb_payment,
         },
-        None,
+        first_hops.as_deref(),
         inflight_htlcs,
     );
 


### PR DESCRIPTION
## Summary

- update the existing same-channel swap test to cover private-channel routing
- pass local usable channels as `first_hops` when route finding starts from our own node

## Root Cause

The swap route lookup did not provide LDK with local first-hop channels. That works for public channels discoverable from graph data, but private channels are not in the public graph, so route finding could fail with `No route found` even when a usable local private channel exists.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test test::swap_reverse_same_channel::swap_reverse_private_same_channel -- --exact --test-threads=1 --nocapture`

Fixes #123
