### PR TITLE
feat: add BOLT12 offer support (create + decode)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -241,6 +241,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DecodeLNInvoiceResponse'
+  /decodeoffer:
+    post:
+      tags:
+        - Invoices
+      summary: Decode a BOLT12 offer
+      description: Decode the provided BOLT12 offer string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DecodeOfferRequest'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DecodeOfferResponse'
   /decodergbinvoice:
     post:
       tags:
@@ -705,6 +723,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LNInvoiceResponse'
+  /lnoffer:
+    post:
+      tags:
+        - Invoices
+      summary: Get a BOLT12 offer
+      description: Get a BOLT12 offer to receive a payment
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LNOfferRequest'
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LNOfferResponse'
   /makerexecute:
     post:
       tags:
@@ -1620,6 +1656,14 @@ components:
         invoice:
           type: string
           example: lnbcrt30u1pjv6yzndqud3jxktt5w46x7unfv9kz6mn0v3jsnp4qdpc280eur52luxppv6f3nnj8l6vnd9g2hnv3qv6mjhmhvlzf6327pp5tjjasx6g9dqptea3fhm6yllq5wxzycnnvp8l6wcq3d6j2uvpryuqsp5l8az8x3g8fe05dg7cmgddld3da09nfjvky8xftwsk4cj8p2l7kfq9qyysgqcqpcxqzdylzlwfnkyw3jv344x4rzwgkk53ng0fhxy5rdduk4g5tpvea8xa6rfckkza35va28xjn2tqkhgarcxep5umm4x5k56wfcdvu95eq7qzp20vrl4xz76syapsa3c09j7lg5gerkaj63llj0ark7ph8hfketn6fkqzm8laf66dhsncm23wkwm5l5377we9e8lnlknnkwje5eefkccusqm6rqt8
+    DecodeOfferRequest:
+      type: object
+      required:
+        - offer
+      properties:
+        offer:
+          type: string
+          example: lno1qcp4256ypq...
     DecodeLNInvoiceResponse:
       type: object
       required:
@@ -1663,6 +1707,58 @@ components:
           example: 0343851df9e0e8aff0c10b3498ce723ff4c9b4a855e6c8819adcafbbb3e24ea2af
         network:
           $ref: '#/components/schemas/BitcoinNetwork'
+    DecodeOfferResponse:
+      type: object
+      required:
+        - is_expired
+        - chains
+        - path_count
+        - offer_id
+      properties:
+        amt_msat:
+          type:
+            - integer
+            - 'null'
+          example: 50000
+        description:
+          type:
+            - string
+            - 'null'
+          example: bolt12 test
+        issuer:
+          type:
+            - string
+            - 'null'
+          example: Example node
+        expiry_sec:
+          type:
+            - integer
+            - 'null'
+          example: 1744298100
+        is_expired:
+          type: boolean
+          example: false
+        chains:
+          type: array
+          items:
+            $ref: '#/components/schemas/BitcoinNetwork'
+        supported_quantity_max:
+          type:
+            - integer
+            - 'null'
+          description: Null means a single-item offer, 0 means unbounded quantity.
+          example: 10
+        issuer_signing_pubkey:
+          type:
+            - string
+            - 'null'
+          example: 0343851df9e0e8aff0c10b3498ce723ff4c9b4a855e6c8819adcafbbb3e24ea2af
+        path_count:
+          type: integer
+          example: 1
+        offer_id:
+          type: string
+          example: 6a1ccf1d8a1f3f0f9f2d4ec6a1e8ff7db3b7092bd2e8f25aee72586b1f7cdabc
     DecodeRGBInvoiceRequest:
       type: object
       required:
@@ -2312,6 +2408,53 @@ components:
         invoice:
           type: string
           example: lnbcrt30u1pjv6yzndqud3jxktt5w46x7unfv9kz6mn0v3jsnp4qdpc280eur52luxppv6f3nnj8l6vnd9g2hnv3qv6mjhmhvlzf6327pp5tjjasx6g9dqptea3fhm6yllq5wxzycnnvp8l6wcq3d6j2uvpryuqsp5l8az8x3g8fe05dg7cmgddld3da09nfjvky8xftwsk4cj8p2l7kfq9qyysgqcqpcxqzdylzlwfnkyw3jv344x4rzwgkk53ng0fhxy5rdduk4g5tpvea8xa6rfckkza35va28xjn2tqkhgarcxep5umm4x5k56wfcdvu95eq7qzp20vrl4xz76syapsa3c09j7lg5gerkaj63llj0ark7ph8hfketn6fkqzm8laf66dhsncm23wkwm5l5377we9e8lnlknnkwje5eefkccusqm6rqt8
+    LNOfferRequest:
+      type: object
+      properties:
+        amt_msat:
+          type:
+            - integer
+            - 'null'
+          example: 50000
+        description:
+          type:
+            - string
+            - 'null'
+          example: bolt12 test
+        issuer:
+          type:
+            - string
+            - 'null'
+          example: Example node
+        expiry_sec:
+          type:
+            - integer
+            - 'null'
+          example: 900
+        supported_quantity_max:
+          type:
+            - integer
+            - 'null'
+          description: Null means a single-item offer, 0 means unbounded quantity.
+          example: 10
+        asset_id:
+          type:
+            - string
+            - 'null'
+          example: rgb:CJkb4YZw-jRiz2sk-~PARPio-wtVYI1c-XAEYCqO-wTfvRZ8
+        asset_amount:
+          type:
+            - integer
+            - 'null'
+          example: 42
+    LNOfferResponse:
+      type: object
+      required:
+        - offer
+      properties:
+        offer:
+          type: string
+          example: lno1qcp4256ypq...
     MakerExecuteRequest:
       type: object
       required:
@@ -2812,6 +2955,7 @@ components:
       properties:
         invoice:
           type: string
+          description: A BOLT11 invoice or a BOLT12 offer.
           example: lnbcrt30u1pjv6yzndqud3jxktt5w46x7unfv9kz6mn0v3jsnp4qdpc280eur52luxppv6f3nnj8l6vnd9g2hnv3qv6mjhmhvlzf6327pp5tjjasx6g9dqptea3fhm6yllq5wxzycnnvp8l6wcq3d6j2uvpryuqsp5l8az8x3g8fe05dg7cmgddld3da09nfjvky8xftwsk4cj8p2l7kfq9qyysgqcqpcxqzdylzlwfnkyw3jv344x4rzwgkk53ng0fhxy5rdduk4g5tpvea8xa6rfckkza35va28xjn2tqkhgarcxep5umm4x5k56wfcdvu95eq7qzp20vrl4xz76syapsa3c09j7lg5gerkaj63llj0ark7ph8hfketn6fkqzm8laf66dhsncm23wkwm5l5377we9e8lnlknnkwje5eefkccusqm6rqt8
         amt_msat:
           type:

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -16,13 +16,14 @@ use crate::{
 
 const REVOKED_TOKENS_FILE: &str = "revoked_tokens.txt";
 
-const READ_ONLY_OPS: [&str; 24] = [
+const READ_ONLY_OPS: [&str; 25] = [
     "/assetbalance",
     "/assetmetadata",
     "/btcbalance",
     "/checkindexerurl",
     "/checkproxyendpoint",
     "/decodelninvoice",
+    "/decodeoffer",
     "/decodergbinvoice",
     "/decodeswapstring",
     "/estimatefee",

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,9 @@ pub enum APIError {
     #[error("Failed to create invoice: {0}")]
     FailedInvoiceCreation(String),
 
+    #[error("Failed to create offer: {0}")]
+    FailedOfferCreation(String),
+
     #[error("Failed to issue asset: {0}")]
     FailedIssuingAsset(String),
 
@@ -427,6 +430,7 @@ impl IntoResponse for APIError {
         let (status, error, name) = match self {
             APIError::FailedClosingChannel(_)
             | APIError::FailedInvoiceCreation(_)
+            | APIError::FailedOfferCreation(_)
             | APIError::FailedIssuingAsset(_)
             | APIError::FailedKeysCreation(_, _)
             | APIError::FailedOpenChannel(_)

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -134,6 +134,7 @@ pub(crate) struct PaymentInfo {
     pub(crate) updated_at: u64,
     pub(crate) payee_pubkey: PublicKey,
     pub(crate) expires_at: Option<u64>,
+    pub(crate) payment_hash: Option<PaymentHash>,
 }
 
 impl_writeable_tlv_based!(PaymentInfo, {
@@ -145,6 +146,7 @@ impl_writeable_tlv_based!(PaymentInfo, {
     (10, updated_at, required),
     (12, payee_pubkey, required),
     (14, expires_at, option),
+    (16, payment_hash, option),
 });
 
 pub(crate) struct InboundPaymentInfoStorage {
@@ -363,6 +365,7 @@ impl UnlockedAppState {
                     secret,
                     status,
                     amt_msat,
+                    payment_hash: Some(payment_hash),
                     created_at,
                     updated_at: created_at,
                     payee_pubkey,
@@ -376,6 +379,7 @@ impl UnlockedAppState {
     pub(crate) fn update_outbound_payment(
         &self,
         payment_id: PaymentId,
+        payment_hash: Option<PaymentHash>,
         status: HTLCStatus,
         preimage: Option<PaymentPreimage>,
     ) -> PaymentInfo {
@@ -383,16 +387,27 @@ impl UnlockedAppState {
         let payment_info = outbound.payments.get_mut(&payment_id).unwrap();
         payment_info.status = status;
         payment_info.preimage = preimage;
+        if payment_hash.is_some() {
+            payment_info.payment_hash = payment_hash;
+        }
         payment_info.updated_at = get_current_timestamp();
         let payment = (*payment_info).clone();
         self.save_outbound_payments(outbound);
         payment
     }
 
-    pub(crate) fn update_outbound_payment_status(&self, payment_id: PaymentId, status: HTLCStatus) {
+    pub(crate) fn update_outbound_payment_status(
+        &self,
+        payment_id: PaymentId,
+        status: HTLCStatus,
+        payment_hash: Option<PaymentHash>,
+    ) {
         let mut outbound = self.get_outbound_payments();
         let payment_info = outbound.payments.get_mut(&payment_id).unwrap();
         payment_info.status = status;
+        if payment_hash.is_some() {
+            payment_info.payment_hash = payment_hash;
+        }
         payment_info.updated_at = get_current_timestamp();
         self.save_outbound_payments(outbound);
     }
@@ -1001,6 +1016,7 @@ async fn handle_ldk_events(
             } else {
                 let payment = unlocked_state.update_outbound_payment(
                     payment_id.unwrap(),
+                    Some(payment_hash),
                     HTLCStatus::Succeeded,
                     Some(payment_preimage),
                 );
@@ -1087,7 +1103,11 @@ async fn handle_ldk_events(
                 if unlocked_state.is_maker_swap(&hash) {
                     unlocked_state.update_maker_swap_status(&hash, SwapStatus::Failed);
                 } else {
-                    unlocked_state.update_outbound_payment_status(payment_id, HTLCStatus::Failed);
+                    unlocked_state.update_outbound_payment_status(
+                        payment_id,
+                        HTLCStatus::Failed,
+                        Some(hash),
+                    );
                 }
             } else {
                 tracing::error!(
@@ -1099,7 +1119,7 @@ async fn handle_ldk_events(
                         PaymentFailureReason::RetriesExhausted
                     }
                 );
-                unlocked_state.update_outbound_payment_status(payment_id, HTLCStatus::Failed);
+                unlocked_state.update_outbound_payment_status(payment_id, HTLCStatus::Failed, None);
             }
         }
         Event::InvoiceReceived { .. } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,14 +44,14 @@ use crate::ldk::stop_ldk;
 use crate::routes::{
     address, asset_balance, asset_metadata, backup, btc_balance, change_password,
     check_indexer_url, check_proxy_endpoint, close_channel, connect_peer, create_utxos,
-    decode_ln_invoice, decode_rgb_invoice, decode_swapstring, disconnect_peer, estimate_fee,
-    fail_transfers, get_asset_media, get_channel_id, get_payment, get_swap, inflate, init,
-    invoice_status, issue_asset_cfa, issue_asset_ifa, issue_asset_nia, issue_asset_uda, keysend,
-    list_assets, list_channels, list_payments, list_peers, list_swaps, list_transactions,
-    list_transfers, list_unspents, ln_invoice, lock, maker_execute, maker_init, network_info,
-    node_info, open_channel, post_asset_media, refresh_transfers, restore, revoke_token,
-    rgb_invoice, send_btc, send_onion_message, send_payment, send_rgb, shutdown, sign_message,
-    sync, taker, unlock,
+    decode_ln_invoice, decode_offer, decode_rgb_invoice, decode_swapstring, disconnect_peer,
+    estimate_fee, fail_transfers, get_asset_media, get_channel_id, get_payment, get_swap, inflate,
+    init, invoice_status, issue_asset_cfa, issue_asset_ifa, issue_asset_nia, issue_asset_uda,
+    keysend, list_assets, list_channels, list_payments, list_peers, list_swaps, list_transactions,
+    list_transfers, list_unspents, ln_invoice, ln_offer, lock, maker_execute, maker_init,
+    network_info, node_info, open_channel, post_asset_media, refresh_transfers, restore,
+    revoke_token, rgb_invoice, send_btc, send_onion_message, send_payment, send_rgb, shutdown,
+    sign_message, sync, taker, unlock,
 };
 use crate::utils::{start_daemon, AppState, LOGS_DIR};
 
@@ -117,6 +117,7 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .route("/connectpeer", post(connect_peer))
         .route("/createutxos", post(create_utxos))
         .route("/decodelninvoice", post(decode_ln_invoice))
+        .route("/decodeoffer", post(decode_offer))
         .route("/decodergbinvoice", post(decode_rgb_invoice))
         .route("/decodeswapstring", post(decode_swapstring))
         .route("/disconnectpeer", post(disconnect_peer))
@@ -143,6 +144,7 @@ pub(crate) async fn app(args: UserArgs) -> Result<(Router, Arc<AppState>), AppEr
         .route("/listtransfers", post(list_transfers))
         .route("/listunspents", post(list_unspents))
         .route("/lninvoice", post(ln_invoice))
+        .route("/lnoffer", post(ln_offer))
         .route("/lock", post(lock))
         .route("/makerexecute", post(maker_execute))
         .route("/makerinit", post(maker_init))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -5,13 +5,14 @@ use axum::{
 };
 use axum_extra::extract::WithRejection;
 use biscuit_auth::Biscuit;
+use bitcoin::constants::ChainHash;
 use bitcoin::hashes::sha256::{self, Hash as Sha256};
 use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::PublicKey;
 use bitcoin::Network;
 use hex::DisplayHex;
 use lightning::ln::{channelmanager::OptionalOfferPaymentParams, types::ChannelId};
-use lightning::offers::offer::{self, Offer};
+use lightning::offers::offer::{self, Offer, Quantity};
 use lightning::onion_message::messenger::Destination;
 use lightning::rgb_utils::{
     get_rgb_channel_info_path, get_rgb_payment_info_path, parse_rgb_channel_info,
@@ -63,6 +64,7 @@ use rgb_lib::{
     BitcoinNetwork as RgbLibNetwork, ContractId, RgbTransport,
 };
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU64;
 use std::{
     collections::HashMap,
     net::ToSocketAddrs,
@@ -391,6 +393,40 @@ impl From<RgbLibNetwork> for BitcoinNetwork {
     }
 }
 
+fn chain_hash_to_bitcoin_network(chain_hash: ChainHash) -> Option<BitcoinNetwork> {
+    if chain_hash == ChainHash::using_genesis_block(Network::Bitcoin) {
+        Some(BitcoinNetwork::Mainnet)
+    } else if chain_hash == ChainHash::using_genesis_block(Network::Testnet) {
+        Some(BitcoinNetwork::Testnet)
+    } else if chain_hash == ChainHash::using_genesis_block(Network::Testnet4) {
+        Some(BitcoinNetwork::Testnet4)
+    } else if chain_hash == ChainHash::using_genesis_block(Network::Signet) {
+        Some(BitcoinNetwork::Signet)
+    } else if chain_hash == ChainHash::using_genesis_block(Network::Regtest) {
+        Some(BitcoinNetwork::Regtest)
+    } else {
+        None
+    }
+}
+
+fn quantity_to_supported_quantity_max(quantity: Quantity) -> Option<u64> {
+    match quantity {
+        Quantity::One => None,
+        Quantity::Unbounded => Some(0),
+        Quantity::Bounded(n) => Some(n.get()),
+    }
+}
+
+fn supported_quantity_max_to_quantity(quantity_max: Option<u64>) -> Result<Quantity, APIError> {
+    match quantity_max {
+        None => Ok(Quantity::One),
+        Some(0) => Ok(Quantity::Unbounded),
+        Some(value) => NonZeroU64::new(value)
+            .map(Quantity::Bounded)
+            .ok_or_else(|| APIError::InvalidAmount(s!("supported quantity cannot be zero"))),
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub(crate) struct BlockTime {
     pub(crate) height: u32,
@@ -493,6 +529,11 @@ pub(crate) struct DecodeLNInvoiceRequest {
 }
 
 #[derive(Deserialize, Serialize)]
+pub(crate) struct DecodeOfferRequest {
+    pub(crate) offer: String,
+}
+
+#[derive(Deserialize, Serialize)]
 pub(crate) struct DecodeLNInvoiceResponse {
     pub(crate) amt_msat: Option<u64>,
     pub(crate) expiry_sec: u64,
@@ -503,6 +544,20 @@ pub(crate) struct DecodeLNInvoiceResponse {
     pub(crate) payment_secret: String,
     pub(crate) payee_pubkey: Option<String>,
     pub(crate) network: BitcoinNetwork,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct DecodeOfferResponse {
+    pub(crate) amt_msat: Option<u64>,
+    pub(crate) description: Option<String>,
+    pub(crate) issuer: Option<String>,
+    pub(crate) expiry_sec: Option<u64>,
+    pub(crate) is_expired: bool,
+    pub(crate) chains: Vec<BitcoinNetwork>,
+    pub(crate) supported_quantity_max: Option<u64>,
+    pub(crate) issuer_signing_pubkey: Option<String>,
+    pub(crate) path_count: usize,
+    pub(crate) offer_id: String,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -842,6 +897,22 @@ pub(crate) struct LNInvoiceRequest {
 #[derive(Deserialize, Serialize)]
 pub(crate) struct LNInvoiceResponse {
     pub(crate) invoice: String,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct LNOfferRequest {
+    pub(crate) amt_msat: Option<u64>,
+    pub(crate) description: Option<String>,
+    pub(crate) issuer: Option<String>,
+    pub(crate) expiry_sec: Option<u32>,
+    pub(crate) supported_quantity_max: Option<u64>,
+    pub(crate) asset_id: Option<String>,
+    pub(crate) asset_amount: Option<u64>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct LNOfferResponse {
+    pub(crate) offer: String,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1764,6 +1835,38 @@ pub(crate) async fn decode_ln_invoice(
     }))
 }
 
+pub(crate) async fn decode_offer(
+    State(state): State<Arc<AppState>>,
+    WithRejection(Json(payload), _): WithRejection<Json<DecodeOfferRequest>, APIError>,
+) -> Result<Json<DecodeOfferResponse>, APIError> {
+    let _guard = state.get_unlocked_app_state();
+
+    let offer =
+        Offer::from_str(&payload.offer).map_err(|e| APIError::InvalidInvoice(format!("{e:?}")))?;
+
+    let amt_msat = match offer.amount() {
+        Some(offer::Amount::Bitcoin { amount_msats }) => Some(amount_msats),
+        _ => None,
+    };
+
+    Ok(Json(DecodeOfferResponse {
+        amt_msat,
+        description: offer.description().map(|d| d.to_string()),
+        issuer: offer.issuer().map(|i| i.to_string()),
+        expiry_sec: offer.absolute_expiry().map(|d| d.as_secs()),
+        is_expired: offer.is_expired(),
+        chains: offer
+            .chains()
+            .into_iter()
+            .filter_map(chain_hash_to_bitcoin_network)
+            .collect(),
+        supported_quantity_max: quantity_to_supported_quantity_max(offer.supported_quantity()),
+        issuer_signing_pubkey: offer.issuer_signing_pubkey().map(|p| p.to_string()),
+        path_count: offer.paths().len(),
+        offer_id: hex_str(&offer.id().0),
+    }))
+}
+
 pub(crate) async fn decode_rgb_invoice(
     State(state): State<Arc<AppState>>,
     WithRejection(Json(payload), _): WithRejection<Json<DecodeRGBInvoiceRequest>, APIError>,
@@ -1971,10 +2074,13 @@ pub(crate) async fn get_payment(
     }
 
     for (payment_id, payment_info) in &outbound_payments {
-        let payment_hash = &PaymentHash(payment_id.0);
-        if payment_hash == &requested_ph {
+        let derived_payment_hash = PaymentHash(payment_id.0);
+        if derived_payment_hash == requested_ph
+            || payment_info.payment_hash.as_ref() == Some(&requested_ph)
+        {
+            let payment_hash = payment_info.payment_hash.unwrap_or(derived_payment_hash);
             let rgb_payment_info_path_outbound =
-                get_rgb_payment_info_path(payment_hash, &state.static_state.ldk_data_dir, false);
+                get_rgb_payment_info_path(&payment_hash, &state.static_state.ldk_data_dir, false);
 
             let (asset_amount, asset_id) = if rgb_payment_info_path_outbound.exists() {
                 let info = parse_rgb_payment_info(&rgb_payment_info_path_outbound);
@@ -2310,6 +2416,7 @@ pub(crate) async fn keysend(
                 secret: None,
                 status: HTLCStatus::Pending,
                 amt_msat: Some(amt_msat),
+                payment_hash: Some(payment_hash),
                 created_at,
                 updated_at: created_at,
                 payee_pubkey: dest_pubkey,
@@ -2344,7 +2451,11 @@ pub(crate) async fn keysend(
             }
             Err(e) => {
                 tracing::error!("ERROR: failed to send payment: {:?}", e);
-                unlocked_state.update_outbound_payment_status(payment_id, HTLCStatus::Failed);
+                unlocked_state.update_outbound_payment_status(
+                    payment_id,
+                    HTLCStatus::Failed,
+                    Some(payment_hash),
+                );
                 HTLCStatus::Failed
             }
         };
@@ -2565,10 +2676,12 @@ pub(crate) async fn list_payments(
     }
 
     for (payment_id, payment_info) in &outbound_payments {
-        let payment_hash = &PaymentHash(payment_id.0);
+        let payment_hash = payment_info
+            .payment_hash
+            .unwrap_or(PaymentHash(payment_id.0));
 
         let rgb_payment_info_path_outbound =
-            get_rgb_payment_info_path(payment_hash, &state.static_state.ldk_data_dir, false);
+            get_rgb_payment_info_path(&payment_hash, &state.static_state.ldk_data_dir, false);
 
         let (asset_amount, asset_id) = if rgb_payment_info_path_outbound.exists() {
             let info = parse_rgb_payment_info(&rgb_payment_info_path_outbound);
@@ -2820,6 +2933,7 @@ pub(crate) async fn ln_invoice(
                 secret: Some(*invoice.payment_secret()),
                 status: HTLCStatus::Pending,
                 amt_msat: payload.amt_msat,
+                payment_hash: Some(payment_hash),
                 created_at,
                 updated_at: created_at,
                 payee_pubkey: unlocked_state.channel_manager.get_our_node_id(),
@@ -2829,6 +2943,53 @@ pub(crate) async fn ln_invoice(
 
         Ok(Json(LNInvoiceResponse {
             invoice: invoice.to_string(),
+        }))
+    })
+    .await
+}
+
+pub(crate) async fn ln_offer(
+    State(state): State<Arc<AppState>>,
+    WithRejection(Json(payload), _): WithRejection<Json<LNOfferRequest>, APIError>,
+) -> Result<Json<LNOfferResponse>, APIError> {
+    no_cancel(async move {
+        let guard = state.check_unlocked().await?;
+        let unlocked_state = guard.as_ref().unwrap();
+
+        if payload.asset_id.is_some() || payload.asset_amount.is_some() {
+            return Err(APIError::InvalidRequest(s!(
+                "RGB assets are not yet supported in BOLT12 offers"
+            )));
+        }
+
+        let supported_quantity =
+            supported_quantity_max_to_quantity(payload.supported_quantity_max)?;
+
+        let mut offer_builder = unlocked_state
+            .channel_manager
+            .create_offer_builder()
+            .map_err(|e| APIError::FailedOfferCreation(format!("{e:?}")))?
+            .description(payload.description.unwrap_or_default())
+            .supported_quantity(supported_quantity);
+
+        if let Some(amt_msat) = payload.amt_msat {
+            offer_builder = offer_builder.amount_msats(amt_msat);
+        }
+        if let Some(issuer) = payload.issuer {
+            offer_builder = offer_builder.issuer(issuer);
+        }
+        if let Some(expiry_sec) = payload.expiry_sec {
+            offer_builder = offer_builder.absolute_expiry(Duration::from_secs(
+                get_current_timestamp() + expiry_sec as u64,
+            ));
+        }
+
+        let offer = offer_builder
+            .build()
+            .map_err(|e| APIError::FailedOfferCreation(format!("{e:?}")))?;
+
+        Ok(Json(LNOfferResponse {
+            offer: offer.to_string(),
         }))
     })
     .await
@@ -3729,6 +3890,7 @@ pub(crate) async fn send_payment(
                     secret,
                     status,
                     amt_msat: Some(amt_msat),
+                    payment_hash: None,
                     created_at,
                     updated_at: created_at,
                     payee_pubkey: offer.issuer_signing_pubkey().ok_or(APIError::InvalidInvoice(s!("missing signing pubkey")))?,
@@ -3744,9 +3906,13 @@ pub(crate) async fn send_payment(
                 .pay_for_offer(&offer, Some(amt_msat), payment_id, params);
             if pay.is_err() {
                 tracing::error!("ERROR: failed to pay: {:?}", pay);
-                unlocked_state.update_outbound_payment_status(payment_id, HTLCStatus::Failed);
+                unlocked_state.update_outbound_payment_status(
+                    payment_id,
+                    HTLCStatus::Failed,
+                    None,
+                );
                 status = HTLCStatus::Failed;
-                unlocked_state.update_outbound_payment_status(payment_id, status);
+                unlocked_state.update_outbound_payment_status(payment_id, status, None);
             }
             (payment_id, None, secret)
         } else {
@@ -3813,6 +3979,7 @@ pub(crate) async fn send_payment(
                 }
             };
 
+            let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
             let secret = payment_secret;
             unlocked_state.add_outbound_payment(
                 payment_id,
@@ -3821,13 +3988,13 @@ pub(crate) async fn send_payment(
                     secret,
                     status,
                     amt_msat: Some(amt_msat),
+                    payment_hash: Some(payment_hash),
                     created_at,
                     updated_at: created_at,
                     payee_pubkey: invoice.get_payee_pub_key(),
                     expires_at: None,
                 },
             )?;
-            let payment_hash = PaymentHash(invoice.payment_hash().to_byte_array());
             if let Some((contract_id, rgb_amount)) = rgb_payment {
                 write_rgb_payment_info_file(
                     &PathBuf::from(&state.static_state.ldk_data_dir),
@@ -3857,7 +4024,11 @@ pub(crate) async fn send_payment(
                 Err(e) => {
                     tracing::error!("ERROR: failed to send payment: {:?}", e);
                     status = HTLCStatus::Failed;
-                    unlocked_state.update_outbound_payment_status(payment_id, status);
+                    unlocked_state.update_outbound_payment_status(
+                        payment_id,
+                        status,
+                        Some(payment_hash),
+                    );
                 },
             };
 

--- a/src/test/bolt12.rs
+++ b/src/test/bolt12.rs
@@ -1,0 +1,60 @@
+use super::*;
+use crate::routes::BitcoinNetwork as RouteBitcoinNetwork;
+
+const TEST_DIR_BASE: &str = "tmp/bolt12/";
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn offer_roundtrip() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}offer_roundtrip/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let offer = ln_offer(node2_addr, Some(50_000), Some("bolt12 test"), Some(900))
+        .await
+        .offer;
+    let decoded_offer = decode_offer(node1_addr, &offer).await;
+    assert_eq!(decoded_offer.amt_msat, Some(50_000));
+    assert_eq!(decoded_offer.description, Some("bolt12 test".to_string()));
+    assert!(!decoded_offer.is_expired);
+    assert_eq!(decoded_offer.chains, vec![RouteBitcoinNetwork::Regtest]);
+    assert_eq!(decoded_offer.supported_quantity_max, None);
+    assert!(decoded_offer.path_count > 0);
+
+    let send_payment = send_payment_raw(node1_addr, offer).await;
+    assert_eq!(send_payment.status, HTLCStatus::Pending);
+    let payment_id = send_payment.payment_id;
+
+    let sender_payment =
+        wait_for_ln_payment_by_id(node1_addr, &payment_id, HTLCStatus::Succeeded).await;
+    assert_eq!(sender_payment.amt_msat, Some(50_000));
+    assert!(!sender_payment.inbound);
+    assert_eq!(sender_payment.status, HTLCStatus::Succeeded);
+
+    let receiver_payment = list_payments(node2_addr)
+        .await
+        .into_iter()
+        .find(|payment| payment.inbound && payment.status == HTLCStatus::Succeeded)
+        .expect("expected inbound BOLT12 payment");
+    assert_eq!(receiver_payment.amt_msat, Some(50_000));
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -33,24 +33,24 @@ use crate::routes::{
     AddressResponse, AssetBalanceRequest, AssetBalanceResponse, AssetCFA, AssetIFA, AssetNIA,
     AssetUDA, Assignment, BackupRequest, BtcBalanceRequest, BtcBalanceResponse,
     ChangePasswordRequest, Channel, CloseChannelRequest, ConnectPeerRequest, CreateUtxosRequest,
-    DecodeLNInvoiceRequest, DecodeLNInvoiceResponse, DecodeRGBInvoiceRequest,
-    DecodeRGBInvoiceResponse, DecodeSwapstringRequest, DecodeSwapstringResponse,
-    DisconnectPeerRequest, EmptyResponse, FailTransfersRequest, FailTransfersResponse,
-    GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest, GetChannelIdResponse,
-    GetPaymentRequest, GetPaymentResponse, GetSwapRequest, GetSwapResponse, HTLCStatus,
-    InflateRequest, InflateResponse, InitRequest, InitResponse, InvoiceStatus,
+    DecodeLNInvoiceRequest, DecodeLNInvoiceResponse, DecodeOfferRequest, DecodeOfferResponse,
+    DecodeRGBInvoiceRequest, DecodeRGBInvoiceResponse, DecodeSwapstringRequest,
+    DecodeSwapstringResponse, DisconnectPeerRequest, EmptyResponse, FailTransfersRequest,
+    FailTransfersResponse, GetAssetMediaRequest, GetAssetMediaResponse, GetChannelIdRequest,
+    GetChannelIdResponse, GetPaymentRequest, GetPaymentResponse, GetSwapRequest, GetSwapResponse,
+    HTLCStatus, InflateRequest, InflateResponse, InitRequest, InitResponse, InvoiceStatus,
     InvoiceStatusRequest, InvoiceStatusResponse, IssueAssetCFARequest, IssueAssetCFAResponse,
     IssueAssetIFARequest, IssueAssetIFAResponse, IssueAssetNIARequest, IssueAssetNIAResponse,
     IssueAssetUDARequest, IssueAssetUDAResponse, KeysendRequest, KeysendResponse, LNInvoiceRequest,
-    LNInvoiceResponse, ListAssetsRequest, ListAssetsResponse, ListChannelsResponse,
-    ListPaymentsResponse, ListPeersResponse, ListSwapsResponse, ListTransactionsRequest,
-    ListTransactionsResponse, ListTransfersRequest, ListTransfersResponse, ListUnspentsRequest,
-    ListUnspentsResponse, MakerExecuteRequest, MakerInitRequest, MakerInitResponse,
-    NetworkInfoResponse, NodeInfoResponse, OpenChannelRequest, OpenChannelResponse, Payment, Peer,
-    PostAssetMediaResponse, Recipient, RefreshRequest, RestoreRequest, RevokeTokenRequest,
-    RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest, SendBtcResponse, SendPaymentRequest,
-    SendPaymentResponse, SendRgbRequest, SendRgbResponse, Swap, SwapStatus, TakerRequest,
-    Transaction, Transfer, UnlockRequest, Unspent, WitnessData,
+    LNInvoiceResponse, LNOfferRequest, LNOfferResponse, ListAssetsRequest, ListAssetsResponse,
+    ListChannelsResponse, ListPaymentsResponse, ListPeersResponse, ListSwapsResponse,
+    ListTransactionsRequest, ListTransactionsResponse, ListTransfersRequest, ListTransfersResponse,
+    ListUnspentsRequest, ListUnspentsResponse, MakerExecuteRequest, MakerInitRequest,
+    MakerInitResponse, NetworkInfoResponse, NodeInfoResponse, OpenChannelRequest,
+    OpenChannelResponse, Payment, Peer, PostAssetMediaResponse, Recipient, RefreshRequest,
+    RestoreRequest, RevokeTokenRequest, RgbInvoiceRequest, RgbInvoiceResponse, SendBtcRequest,
+    SendBtcResponse, SendPaymentRequest, SendPaymentResponse, SendRgbRequest, SendRgbResponse,
+    Swap, SwapStatus, TakerRequest, Transaction, Transfer, UnlockRequest, Unspent, WitnessData,
 };
 use crate::utils::{hex_str, hex_str_to_vec, ELECTRUM_URL_REGTEST, LDK_DIR, PROXY_ENDPOINT_LOCAL};
 
@@ -509,6 +509,24 @@ async fn decode_ln_invoice(node_address: SocketAddr, invoice: &str) -> DecodeLNI
     check_response_is_ok(res)
         .await
         .json::<DecodeLNInvoiceResponse>()
+        .await
+        .unwrap()
+}
+
+async fn decode_offer(node_address: SocketAddr, offer: &str) -> DecodeOfferResponse {
+    println!("decoding offer {offer} for node {node_address}");
+    let payload = DecodeOfferRequest {
+        offer: offer.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/decodeoffer"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<DecodeOfferResponse>()
         .await
         .unwrap()
 }
@@ -1079,6 +1097,35 @@ async fn ln_invoice(
     check_response_is_ok(res)
         .await
         .json::<LNInvoiceResponse>()
+        .await
+        .unwrap()
+}
+
+async fn ln_offer(
+    node_address: SocketAddr,
+    amt_msat: Option<u64>,
+    description: Option<&str>,
+    expiry_sec: Option<u32>,
+) -> LNOfferResponse {
+    println!("generating offer for node {node_address}");
+    let payload = LNOfferRequest {
+        amt_msat,
+        description: description.map(|d| d.to_string()),
+        issuer: None,
+        expiry_sec,
+        supported_quantity_max: None,
+        asset_id: None,
+        asset_amount: None,
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/lnoffer"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    check_response_is_ok(res)
+        .await
+        .json::<LNOfferResponse>()
         .await
         .unwrap()
 }
@@ -1865,6 +1912,30 @@ async fn wait_for_ln_payment(
     }
 }
 
+// Wait for an outbound payment identified by its payment_id (not payment_hash).
+// BOLT12 offer payments do not expose the payment hash up front, so they are
+// tracked and looked up by payment_id via getpayment.
+async fn wait_for_ln_payment_by_id(
+    node_address: SocketAddr,
+    payment_id: &str,
+    expected_status: HTLCStatus,
+) -> Payment {
+    println!(
+        "waiting for LN payment {payment_id} to become {expected_status:?} on node {node_address}"
+    );
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        let payment = get_payment(node_address, payment_id).await;
+        if payment.status == expected_status {
+            return payment;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 40.0 {
+            panic!("cannot find payment in status {expected_status}")
+        }
+    }
+}
+
 async fn wait_for_swap_status(
     node_address: SocketAddr,
     payment_hash: &str,
@@ -2044,6 +2115,7 @@ pub fn mock_fee(fee: u32) -> u32 {
 
 mod authentication;
 mod backup_and_restore;
+mod bolt12;
 mod close_coop_nobtc_acceptor;
 mod close_coop_other_side;
 mod close_coop_standard;


### PR DESCRIPTION
Closes #130.

Adds BOLT12 **payee** support so a node can create and inspect offers, completing
the loop with the existing pay path (`/sendpayment` → `pay_for_offer`).

## What this adds

- **`POST /lnoffer`** — create a reusable BOLT12 offer (`amt_msat`, `description`,
  `issuer`, `expiry_sec`, `supported_quantity_max`). Returns `{ "offer": "lno1…" }`.
- **`POST /decodeoffer`** — decode/inspect an offer: amount, description, issuer,
  expiry, `is_expired`, supported chains, `supported_quantity_max`, issuer signing
  pubkey, blinded-path count, `offer_id`. Registered as a read-only op.

## Outbound payment tracking

Offer payments don't expose the payment hash up front (`payment_id != payment_hash`),
so an explicit `payment_hash` is now tracked on `PaymentInfo` and threaded through the
outbound-payment update paths. This lets `/getpayment` and `/listpayments` resolve the
RGB payment-info file and report status correctly for offer-initiated payments.

**Backward compatible:** `payment_hash` is **appended** to the `PaymentInfo` TLV stream
at the next free type id (`16, payment_hash, option`); existing type ids are unchanged,
so already-persisted payments continue to deserialize.

## Scope

BTC-only. `asset_id` / `asset_amount` are reserved in the `/lnoffer` request schema but
currently rejected (`400 "RGB assets are not yet supported in BOLT12 offers"`) so the
wire format is forward-compatible with the RGB-assets-in-BOLT12 follow-up without a
breaking change. See #130 for the follow-up scope.

## Testing

- `cargo build` / `cargo clippy --all-targets -D warnings` / `cargo fmt` — clean.
- New `offer_roundtrip` integration test (create → decode → pay → receive over a
  regtest channel), plus existing `payment::success`, `restart`, and
  `backup_and_restore` (which exercise `PaymentInfo` TLV serialize/restore) pass via
  `./regtest.sh`.

## Open questions (see #130)

1. Amount-less offers allowed by default, or opt-in?
2. Default expiry when `expiry_sec` is omitted?
3. A `/listoffers` / offer-persistence story, or fire-and-forget?
