### PR TITLE
Network serialization round-trip fails for mainnet and signetcustom

### DIFF
--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -885,3 +885,25 @@ pub(crate) fn get_rgb_channel_info_optional(
     let rgb_info = parse_rgb_channel_info(&info_file_path);
     Some((rgb_info, info_file_path))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bitcoin_network_serialization_round_trips() {
+        for network in [
+            BitcoinNetwork::Mainnet,
+            BitcoinNetwork::Testnet,
+            BitcoinNetwork::Testnet4,
+            BitcoinNetwork::Signet,
+            BitcoinNetwork::Regtest,
+            BitcoinNetwork::SignetCustom,
+        ] {
+            assert!(
+                Network::from_str(&network.to_string().to_lowercase()).is_ok(),
+                "{network:?} does not parse back"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`WalletSource::list_confirmed_utxos` converts the wallet network by serializing it to a string and parsing it back: `Network::from_str(&self.bitcoin_network().to_string().to_lowercase()).unwrap()`. `rgb_lib::BitcoinNetwork`'s `Display` delegates to `Debug`, so `Mainnet` serializes as `"mainnet"` and `SignetCustom` as `"signetcustom"`, neither of which `bitcoin::Network::from_str` accepts, and the `.unwrap()` panics deterministically the first time `Event::BumpTransaction` fires on those networks (anchor CPFP: force closes, HTLC resolution). Since the panic happens inside the event-handler future, it also kills the spawned `process_events_async` task, leaving the node running without event processing.

The added unit test runs the same round-trip for every `BitcoinNetwork` variant and fails on `Mainnet` (`ParseNetworkError("mainnet")`); with that variant excluded it fails on `SignetCustom` too. The existing suite never catches this because it runs on regtest, whose network name parses back fine.
