### PR TITLE
Reject a colored channel open with no allocation slot available

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -3492,6 +3492,19 @@ pub(crate) async fn open_channel(
             if *asset_amount > balance.spendable {
                 return Err(APIError::InsufficientAssets);
             }
+            // funding the channel will need a colorable UTXO for the change allocation
+            if !unlocked_state
+                .rgb_list_unspents(false, true)?
+                .iter()
+                .any(|u| {
+                    u.utxo.colorable
+                        && u.utxo.exists
+                        && u.pending_blinded == 0
+                        && u.rgb_allocations.is_empty()
+                })
+            {
+                return Err(APIError::NoAvailableUtxos);
+            }
             let schema = unlocked_state
                 .rgb_get_asset_metadata(*contract_id)?
                 .asset_schema;

--- a/src/test/openchannel_fail.rs
+++ b/src/test/openchannel_fail.rs
@@ -21,6 +21,36 @@ async fn openchannel_fail() {
     let node2_info = node_info(node2_addr).await;
     let node2_pubkey = node2_info.pubkey;
 
+    // no colorable UTXO left for the change allocation
+    let res = open_channel_raw(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(31_000),
+        None,
+        Some(500),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        None,
+        true,
+        true,
+    )
+    .await;
+    check_response_is_nok(
+        res.unwrap_err(),
+        reqwest::StatusCode::FORBIDDEN,
+        "No uncolored UTXOs are available",
+        "NoAvailableUtxos",
+    )
+    .await;
+
+    let channels_1 = list_channels(node1_addr).await;
+    let channels_2 = list_channels(node2_addr).await;
+    assert_eq!(channels_1.len(), 0);
+    assert_eq!(channels_2.len(), 0);
+
     // insufficient BTC funds
     let res = open_channel_raw(
         node1_addr,


### PR DESCRIPTION
Fixes #140.

`open_channel` already rejects up front what it can determine from local wallet state — capacity above `balance.colored.spendable`, asset amount above `balance.spendable`. This adds the remaining check of the same kind: whether any colorable UTXO has a free allocation slot for the funding's change allocation.

Without it the request returns `200 OK`, the channel is negotiated with the peer, and the funding then fails in `FundingGenerationReady`, where the only way out is force-closing the channel that has just been negotiated — with the caller already told the open succeeded.

The first commit adds the case to `openchannel_fail`, at the point where the issuance has taken the node's only colorable UTXO, and fails on its own. The second makes it pass. `InsufficientAllocationSlots` already maps to `NoAvailableUtxos`, whose message (`hint: call createutxos`) is what a caller needs, so no new error variant.

This does not make the abort impossible — concurrent opens can each pass the check and then contend for the same slot, and rgb-lib can also consume a free UTXO as an extra BTC input — so `FundingGenerationReady` still has to handle the error. It removes the deterministic case, where the wallet has no free slot at all.
