### PR TITLE
replace magic-crypt with scrypt and XChaCha20Poly1305

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,17 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher 0.4.4",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,15 +742,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,15 +764,6 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-
-[[package]]
-name = "cbc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
-dependencies = [
- "cipher 0.4.4",
-]
 
 [[package]]
 name = "cc"
@@ -1060,15 +1031,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc-any"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46db9f663dfb869b80fcf59e32d7a80fc6c464a4f6328f3f06a00f5e36d05f8c"
-dependencies = [
- "debug-helper",
-]
-
-[[package]]
 name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,12 +1188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debug-helper"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a4af69c60438a1a82af89d362f4729fd38db7b73f305a237636fad31ceb2bf"
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,15 +1247,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.119",
  "unicode-xid",
-]
-
-[[package]]
-name = "des"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
-dependencies = [
- "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2311,7 +2258,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -2658,22 +2604,6 @@ dependencies = [
  "nix",
  "serde",
  "winapi",
-]
-
-[[package]]
-name = "magic-crypt"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "844b6169eeaae32ae8a61855964331a67f12d2afba9170303fbd3e3c2a861a52"
-dependencies = [
- "aes",
- "base64 0.22.1",
- "cbc",
- "crc-any",
- "des",
- "md-5",
- "sha2 0.10.9",
- "tiger",
 ]
 
 [[package]]
@@ -3854,7 +3784,6 @@ dependencies = [
  "lightning-net-tokio",
  "lightning-persister",
  "lightning-rapid-gossip-sync",
- "magic-crypt",
  "once_cell",
  "rand 0.8.7",
  "regex",
@@ -3874,7 +3803,6 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "tracing-test",
- "typenum",
  "uuid",
  "walkdir",
  "zip 2.4.2",
@@ -5216,15 +5144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tiger"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579abbce4ad73b04386dbeb34369c9873a8f9b749c7b99cbf479a2949ff715ed"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ lightning-macros = { version = "0.2.0" }
 lightning-net-tokio = { version = "0.2.0" }
 lightning-persister = { version = "0.2.0", path = "./rust-lightning/lightning-persister", features = ["tokio"] }
 lightning-rapid-gossip-sync = { version = "0.2.0", path = "./rust-lightning/lightning-rapid-gossip-sync" }
-magic-crypt = "4.0.1"
 rand = "0.8.5"
 regex = { version = "1.11", default-features = false }
 rgb-lib = { version = "=0.3.0-beta.7", features = [
@@ -52,7 +51,6 @@ tower-http = { version = "0.6.1", features = ["cors", "limit", "trace"] }
 tracing = "0.1"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-typenum = "1.17.0"
 uuid = { version = "1.11.0", default-features = false, features = ["v4"] }
 walkdir = "2.5.0"
 zip = { version = "2.2.0", default-features = false, features = ["time", "zstd"] }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,11 +1,8 @@
 use amplify::s;
 use chacha20poly1305::aead::{generic_array::GenericArray, stream};
-use chacha20poly1305::{Key, KeyInit, XChaCha20Poly1305};
 use rand::{distributions::Alphanumeric, Rng};
-use scrypt::password_hash::{PasswordHasher, Salt};
-use scrypt::Scrypt;
+use scrypt::password_hash::Salt;
 use tempfile::TempDir;
-use typenum::consts::U32;
 use walkdir::WalkDir;
 use zip::write::SimpleFileOptions;
 
@@ -13,12 +10,13 @@ use std::fs::{create_dir_all, read_to_string, remove_file, write, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
+use crate::crypto::{aead_from_key, derive_key, KdfParams, KEY_LEN};
 use crate::error::APIError;
 use crate::utils::LOGS_DIR;
 
 const BACKUP_BUFFER_LEN_ENCRYPT: usize = 239; // 255 max, leaving 16 for the checksum
 const BACKUP_BUFFER_LEN_DECRYPT: usize = BACKUP_BUFFER_LEN_ENCRYPT + 16;
-const BACKUP_KEY_LENGTH: usize = 32;
+const BACKUP_SALT_LENGTH: usize = 32;
 const BACKUP_NONCE_LENGTH: usize = 19;
 const BACKUP_VERSION: u8 = 1;
 
@@ -32,7 +30,7 @@ struct BackupPaths {
 }
 
 struct CypherSecrets {
-    key: GenericArray<u8, U32>,
+    key: [u8; KEY_LEN],
     nonce: [u8; BACKUP_NONCE_LENGTH],
 }
 
@@ -56,7 +54,7 @@ pub(crate) fn do_backup(
     let files = get_backup_paths(&tmp_base_path)?;
     let salt: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)
-        .take(BACKUP_KEY_LENGTH)
+        .take(BACKUP_SALT_LENGTH)
         .map(char::from)
         .collect();
     tracing::debug!("using generated salt: {}", &salt);
@@ -251,20 +249,14 @@ fn get_cypher_secrets(
     salt_str: &str,
     nonce_str: &str,
 ) -> Result<CypherSecrets, APIError> {
-    // hash password using scrypt with the provided salt
-    let password_bytes = password.as_bytes();
+    // derive the key from the password, hashing it with scrypt and the provided salt
     let salt = Salt::from_b64(salt_str)
         .map_err(|e| APIError::Unexpected(format!("Failed to create salt: {e}")))?;
-    let password_hash = Scrypt
-        .hash_password(password_bytes, salt)
-        .map_err(|e| APIError::Unexpected(format!("Failed to hash password: {e}")))?;
-    let hash_output = password_hash
-        .hash
-        .ok_or_else(|| APIError::Unexpected(s!("Failed to hash password")))?;
-    let hash = hash_output.as_bytes();
-
-    // get key from password hash
-    let key = Key::clone_from_slice(&hash[..BACKUP_KEY_LENGTH]);
+    let mut salt_buf = [0u8; Salt::MAX_LENGTH];
+    let salt_bytes = salt
+        .decode_b64(&mut salt_buf)
+        .map_err(|e| APIError::Unexpected(format!("Failed to decode salt: {e}")))?;
+    let key = derive_key(password, salt_bytes, KdfParams::BACKUP_V1)?;
 
     // get nonce from provided str
     let nonce_bytes = nonce_str.as_bytes();
@@ -288,7 +280,7 @@ fn encrypt_file(
     // - stream mode required as files to encrypt may be big, so avoiding a memory buffer
 
     // setup
-    let aead = XChaCha20Poly1305::new(&cypher_secrets.key);
+    let aead = aead_from_key(&cypher_secrets.key);
     let nonce = GenericArray::from_slice(&cypher_secrets.nonce);
     let mut stream_encryptor = stream::EncryptorBE32::from_aead(aead, nonce);
     let mut buffer = [0u8; BACKUP_BUFFER_LEN_ENCRYPT];
@@ -328,7 +320,7 @@ fn decrypt_file(
     let cypher_secrets = get_cypher_secrets(password, salt_str, nonce_str)?;
 
     // setup
-    let aead = XChaCha20Poly1305::new(&cypher_secrets.key);
+    let aead = aead_from_key(&cypher_secrets.key);
     let nonce = GenericArray::from_slice(&cypher_secrets.nonce);
     let mut stream_decryptor = stream::DecryptorBE32::from_aead(aead, nonce);
     let mut buffer = [0u8; BACKUP_BUFFER_LEN_DECRYPT];

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,335 @@
+//! Encrypted mnemonic file format, plus the password-based key derivation and cipher setup it
+//! shares with the streaming backup encryption in [`crate::backup`].
+//!
+//! Keys are derived with scrypt and data is encrypted with XChaCha20Poly1305.
+
+use amplify::s;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use chacha20poly1305::aead::Aead;
+use chacha20poly1305::{Key, KeyInit, XChaCha20Poly1305, XNonce};
+use rand::RngCore;
+use scrypt::{scrypt, Params as ScryptParams};
+
+use crate::error::APIError;
+
+// Length of the keys derived from a password.
+pub(crate) const KEY_LEN: usize = 32;
+
+const MNEMONIC_VERSION: u8 = 1;
+const MNEMONIC_SALT_LEN: usize = 16;
+const MNEMONIC_NONCE_LEN: usize = 24;
+// Bytes taken by the version and the work factors, which precede the salt and the nonce in a
+// mnemonic header.
+const MNEMONIC_HEADER_PREFIX_LEN: usize = 1 + 1 + 4 + 4;
+const MNEMONIC_HEADER_LEN: usize =
+    MNEMONIC_HEADER_PREFIX_LEN + MNEMONIC_SALT_LEN + MNEMONIC_NONCE_LEN;
+
+// The scrypt CPU/memory cost of the work factors.
+const CURRENT_LOG_N: u8 = 17;
+const BACKUP_V1_LOG_N: u8 = 17;
+
+// The test build is unoptimized, which makes scrypt about 30 times slower,
+// therefore the work factors are lowered for tests.
+const TEST_LOG_N: u8 = 10;
+
+// The scrypt work factors.
+//
+// Values are pinned here instead of being taken from `ScryptParams::recommended()`, whose
+// defaults can change between crate releases and would then leave already encrypted data
+// undecryptable.
+#[derive(Clone, Copy)]
+pub(crate) struct KdfParams {
+    log_n: u8,
+    r: u32,
+    p: u32,
+}
+
+impl KdfParams {
+    // Work factors used for newly encrypted data.
+    pub(crate) const CURRENT: Self = Self {
+        log_n: if cfg!(test) {
+            TEST_LOG_N
+        } else {
+            CURRENT_LOG_N
+        },
+        r: 8,
+        p: 1,
+    };
+
+    // Work factors of backup format version 1, which has no field to record them and therefore
+    // requires these values to stay unchanged.
+    pub(crate) const BACKUP_V1: Self = Self {
+        log_n: if cfg!(test) {
+            TEST_LOG_N
+        } else {
+            BACKUP_V1_LOG_N
+        },
+        r: 8,
+        p: 1,
+    };
+
+    // Highest accepted work factors: scrypt allocates `128 * r * 2^log_n` bytes, so reading back
+    // unbounded values would let a damaged file exhaust the available memory
+    const MAX_LOG_N: u8 = 20;
+    const MAX_R: u32 = 32;
+    const MAX_P: u32 = 16;
+
+    // Returns `None` if the given work factors are out of range or rejected by scrypt.
+    fn checked(log_n: u8, r: u32, p: u32) -> Option<Self> {
+        let in_range = log_n <= Self::MAX_LOG_N
+            && (1..=Self::MAX_R).contains(&r)
+            && (1..=Self::MAX_P).contains(&p);
+        (in_range && ScryptParams::new(log_n, r, p, KEY_LEN).is_ok()).then_some(Self {
+            log_n,
+            r,
+            p,
+        })
+    }
+
+    fn to_scrypt(self) -> ScryptParams {
+        ScryptParams::new(self.log_n, self.r, self.p, KEY_LEN).expect("checked work factors")
+    }
+}
+
+// Derive an encryption key from the given password and salt.
+pub(crate) fn derive_key(
+    password: &str,
+    salt: &[u8],
+    params: KdfParams,
+) -> Result<[u8; KEY_LEN], APIError> {
+    let mut key = [0u8; KEY_LEN];
+    scrypt(password.as_bytes(), salt, &params.to_scrypt(), &mut key)
+        .map_err(|e| APIError::Unexpected(format!("Failed to derive key: {e}")))?;
+    Ok(key)
+}
+
+// Build an XChaCha20Poly1305 AEAD from a key returned by [`derive_key`].
+pub(crate) fn aead_from_key(key: &[u8; KEY_LEN]) -> XChaCha20Poly1305 {
+    XChaCha20Poly1305::new(Key::from_slice(key))
+}
+
+// Data preceding the ciphertext of an encrypted mnemonic.
+//
+// It is serialized as: version (1 byte), scrypt `log_n` (1 byte), scrypt `r` (4 bytes, big
+// endian), scrypt `p` (4 bytes, big endian), salt, nonce.
+struct MnemonicHeader {
+    params: KdfParams,
+    salt: [u8; MNEMONIC_SALT_LEN],
+    nonce: [u8; MNEMONIC_NONCE_LEN],
+}
+
+impl MnemonicHeader {
+    fn encode(&self) -> Vec<u8> {
+        let mut encoded = Vec::with_capacity(MNEMONIC_HEADER_LEN);
+        encoded.push(MNEMONIC_VERSION);
+        encoded.push(self.params.log_n);
+        encoded.extend_from_slice(&self.params.r.to_be_bytes());
+        encoded.extend_from_slice(&self.params.p.to_be_bytes());
+        encoded.extend_from_slice(&self.salt);
+        encoded.extend_from_slice(&self.nonce);
+        encoded
+    }
+
+    fn decode(encoded: &[u8; MNEMONIC_HEADER_LEN]) -> Result<Self, APIError> {
+        let version = encoded[0];
+        if version != MNEMONIC_VERSION {
+            return Err(APIError::CorruptedMnemonic(format!(
+                "unsupported version {version}"
+            )));
+        }
+        let log_n = encoded[1];
+        let r = u32::from_be_bytes(encoded[2..6].try_into().expect("4 bytes"));
+        let p = u32::from_be_bytes(encoded[6..10].try_into().expect("4 bytes"));
+        let params = KdfParams::checked(log_n, r, p).ok_or_else(|| {
+            APIError::CorruptedMnemonic(format!(
+                "unsupported scrypt work factors (log_n {log_n}, r {r}, p {p})"
+            ))
+        })?;
+        let salt_end = MNEMONIC_HEADER_PREFIX_LEN + MNEMONIC_SALT_LEN;
+
+        Ok(Self {
+            params,
+            salt: encoded[MNEMONIC_HEADER_PREFIX_LEN..salt_end]
+                .try_into()
+                .expect("salt length"),
+            nonce: encoded[salt_end..].try_into().expect("nonce length"),
+        })
+    }
+}
+
+// Encrypt a mnemonic with the given password.
+//
+// The work factors are stored along with the ciphertext, so raising the ones used for new data
+// keeps previously encrypted mnemonics readable.
+pub(crate) fn encrypt_mnemonic(password: &str, mnemonic: &str) -> Result<String, APIError> {
+    let mut salt = [0u8; MNEMONIC_SALT_LEN];
+    let mut nonce = [0u8; MNEMONIC_NONCE_LEN];
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(&mut salt);
+    rng.fill_bytes(&mut nonce);
+
+    encrypt_with(
+        password,
+        KdfParams::CURRENT,
+        salt,
+        nonce,
+        mnemonic.as_bytes(),
+    )
+}
+
+// Encrypt a mnemonic with the given password, work factors, salt and nonce.
+//
+// Split out of [`encrypt_mnemonic`] so that tests can encrypt deterministically, and with work
+// factors cheaper than the current ones, without reimplementing the payload layout.
+fn encrypt_with(
+    password: &str,
+    params: KdfParams,
+    salt: [u8; MNEMONIC_SALT_LEN],
+    nonce: [u8; MNEMONIC_NONCE_LEN],
+    plaintext: &[u8],
+) -> Result<String, APIError> {
+    let key = derive_key(password, &salt, params)?;
+    let ciphertext = aead_from_key(&key)
+        .encrypt(XNonce::from_slice(&nonce), plaintext)
+        .map_err(|e| APIError::Unexpected(format!("Failed to encrypt mnemonic: {e}")))?;
+
+    let mut payload = MnemonicHeader {
+        params,
+        salt,
+        nonce,
+    }
+    .encode();
+    payload.extend_from_slice(&ciphertext);
+
+    Ok(BASE64.encode(payload))
+}
+
+// Decrypt a mnemonic encrypted with [`encrypt_mnemonic`].
+//
+// A wrong password is the only cause for [`APIError::WrongPassword`], data that cannot be
+// interpreted is reported as [`APIError::CorruptedMnemonic`] instead.
+pub(crate) fn decrypt_mnemonic(password: &str, encrypted: &str) -> Result<String, APIError> {
+    let payload = BASE64
+        .decode(encrypted)
+        .map_err(|e| APIError::CorruptedMnemonic(format!("invalid base64: {e}")))?;
+    let Some((header, ciphertext)) = payload.split_first_chunk::<MNEMONIC_HEADER_LEN>() else {
+        return Err(APIError::CorruptedMnemonic(format!(
+            "got {} bytes, expected more than {MNEMONIC_HEADER_LEN}",
+            payload.len()
+        )));
+    };
+    if ciphertext.is_empty() {
+        return Err(APIError::CorruptedMnemonic(s!("no ciphertext")));
+    }
+    let header = MnemonicHeader::decode(header)?;
+
+    let key = derive_key(password, &header.salt, header.params)?;
+    let plaintext = aead_from_key(&key)
+        .decrypt(XNonce::from_slice(&header.nonce), ciphertext)
+        .map_err(|_| APIError::WrongPassword)?;
+
+    String::from_utf8(plaintext).map_err(|_| APIError::CorruptedMnemonic(s!("invalid UTF-8")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PASSWORD: &str = "password123";
+    const MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    // Work factors differing from the ones used for new data, so that data encrypted with them can
+    // only be decrypted if the work factors stored along with it are honored.
+    const OTHER_PARAMS: KdfParams = KdfParams {
+        log_n: TEST_LOG_N + 1,
+        r: 8,
+        p: 1,
+    };
+
+    fn encrypt_with_other_params(plaintext: &[u8]) -> String {
+        let salt = [7u8; MNEMONIC_SALT_LEN];
+        let nonce = [9u8; MNEMONIC_NONCE_LEN];
+        encrypt_with(PASSWORD, OTHER_PARAMS, salt, nonce, plaintext).unwrap()
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let encrypted = encrypt_mnemonic(PASSWORD, MNEMONIC).unwrap();
+        assert_eq!(decrypt_mnemonic(PASSWORD, &encrypted).unwrap(), MNEMONIC);
+    }
+
+    #[test]
+    fn real_work_factors_are_usable() {
+        // everywhere else in this module a test build swaps the work factors of a real build for a
+        // much cheaper cost, so this is the only place checking the real ones are usable
+        let current = KdfParams {
+            log_n: CURRENT_LOG_N,
+            ..KdfParams::CURRENT
+        };
+        let backup_v1 = KdfParams {
+            log_n: BACKUP_V1_LOG_N,
+            ..KdfParams::BACKUP_V1
+        };
+
+        // backups derive a key without going through the mnemonic format
+        assert!(KdfParams::checked(backup_v1.log_n, backup_v1.r, backup_v1.p).is_some());
+        derive_key(PASSWORD, &[7u8; MNEMONIC_SALT_LEN], backup_v1).unwrap();
+
+        // mnemonics store their work factors, so a roundtrip also covers reading them back
+        assert!(KdfParams::checked(current.log_n, current.r, current.p).is_some());
+        let encrypted = encrypt_with(
+            PASSWORD,
+            current,
+            [7u8; MNEMONIC_SALT_LEN],
+            [9u8; MNEMONIC_NONCE_LEN],
+            MNEMONIC.as_bytes(),
+        )
+        .unwrap();
+        assert_eq!(decrypt_mnemonic(PASSWORD, &encrypted).unwrap(), MNEMONIC);
+    }
+
+    #[test]
+    fn stored_work_factors_are_used() {
+        // decrypting data encrypted with work factors other than the current ones can only
+        // succeed if the ones stored along with it are being used
+        let encrypted = encrypt_with_other_params(MNEMONIC.as_bytes());
+        assert_eq!(decrypt_mnemonic(PASSWORD, &encrypted).unwrap(), MNEMONIC);
+    }
+
+    #[test]
+    fn wrong_password_is_detected() {
+        let encrypted = encrypt_with_other_params(MNEMONIC.as_bytes());
+        assert!(matches!(
+            decrypt_mnemonic("wrong-password", &encrypted),
+            Err(APIError::WrongPassword)
+        ));
+    }
+
+    #[test]
+    fn corrupted_data_is_not_a_wrong_password() {
+        let with_header = |version: u8, log_n: u8, r: u32, p: u32| {
+            let mut payload = vec![version, log_n];
+            payload.extend_from_slice(&r.to_be_bytes());
+            payload.extend_from_slice(&p.to_be_bytes());
+            payload.extend_from_slice(&[0u8; MNEMONIC_SALT_LEN + MNEMONIC_NONCE_LEN]);
+            payload.extend_from_slice(b"ciphertext");
+            BASE64.encode(payload)
+        };
+
+        for encrypted in [
+            s!("not base64 at all"),
+            // truncated, then complete but without any ciphertext
+            BASE64.encode([0u8; MNEMONIC_HEADER_LEN - 1]),
+            BASE64.encode([0u8; MNEMONIC_HEADER_LEN]),
+            encrypt_with_other_params(b"\xff not valid UTF-8"),
+            with_header(MNEMONIC_VERSION + 1, 17, 8, 1),
+            with_header(MNEMONIC_VERSION, KdfParams::MAX_LOG_N + 1, 8, 1),
+            with_header(MNEMONIC_VERSION, 17, 0, 1),
+            with_header(MNEMONIC_VERSION, 17, 8, 0),
+        ] {
+            assert!(matches!(
+                decrypt_mnemonic(PASSWORD, &encrypted),
+                Err(APIError::CorruptedMnemonic(_))
+            ));
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,9 @@ pub enum APIError {
     #[error("Consignment not found")]
     ConsignmentNotFound,
 
+    #[error("The stored mnemonic is corrupted: {0}")]
+    CorruptedMnemonic(String),
+
     #[error("Another payment for this invoice is already in status {0}")]
     DuplicatePayment(String),
 
@@ -446,7 +449,8 @@ impl From<RgbLibError> for APIError {
 impl APIError {
     fn status_code(&self) -> StatusCode {
         match self {
-            APIError::FailedClosingChannel(_)
+            APIError::CorruptedMnemonic(_)
+            | APIError::FailedClosingChannel(_)
             | APIError::FailedInvoiceCreation(_)
             | APIError::FailedIssuingAsset(_)
             | APIError::FailedKeysCreation(_, _)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod args;
 mod auth;
 mod backup;
 mod bitcoind;
+mod crypto;
 mod disk;
 mod error;
 mod ldk;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -2239,6 +2239,7 @@ pub(crate) async fn init(
         };
 
         encrypt_and_save_mnemonic(payload.password, mnemonic.clone(), &mnemonic_path)?;
+        tracing::info!("Created a new wallet");
 
         Ok(Json(InitResponse { mnemonic }))
     })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,6 @@ use lightning::{
     util::ser::{Writeable, Writer},
 };
 use lightning_persister::fs_store::FilesystemStore;
-use magic_crypt::{new_magic_crypt, MagicCryptTrait};
 use rgb_lib::{bdk_wallet::keys::bip39::Mnemonic, BitcoinNetwork, ContractId};
 use std::{
     collections::HashSet,
@@ -30,6 +29,7 @@ use std::{
 use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
 use tokio_util::sync::CancellationToken;
 
+use crate::crypto::{decrypt_mnemonic, encrypt_mnemonic};
 use crate::ldk::{ChannelIdsMap, Router};
 use crate::rgb::{get_rgb_channel_info_optional, RgbLibWalletWrapper};
 use crate::rgb_file_transfer::RgbFileTransferHandler;
@@ -180,15 +180,14 @@ pub(crate) fn check_password_validity(
     storage_dir_path: &Path,
 ) -> Result<Mnemonic, APIError> {
     let mnemonic_path = get_mnemonic_path(storage_dir_path);
-    if let Ok(encrypted_mnemonic) = fs::read_to_string(mnemonic_path) {
-        let mcrypt = new_magic_crypt!(password, 256);
-        let mnemonic_str = mcrypt
-            .decrypt_base64_to_string(encrypted_mnemonic)
-            .map_err(|_| APIError::WrongPassword)?;
-        Ok(Mnemonic::from_str(&mnemonic_str).expect("valid mnemonic"))
-    } else {
-        Err(APIError::NotInitialized)
-    }
+    let encrypted_mnemonic = match fs::read_to_string(&mnemonic_path) {
+        Ok(encrypted_mnemonic) => encrypted_mnemonic,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(APIError::NotInitialized),
+        Err(e) => return Err(APIError::IO(e)),
+    };
+    let mnemonic_str = decrypt_mnemonic(password, encrypted_mnemonic.trim())?;
+    Mnemonic::from_str(&mnemonic_str)
+        .map_err(|e| APIError::CorruptedMnemonic(format!("invalid mnemonic: {e}")))
 }
 
 pub(crate) fn check_channel_id(channel_id_str: &str) -> Result<ChannelId, APIError> {
@@ -218,18 +217,10 @@ pub(crate) fn encrypt_and_save_mnemonic(
     mnemonic: String,
     mnemonic_path: &Path,
 ) -> Result<(), APIError> {
-    let mcrypt = new_magic_crypt!(password, 256);
-    let encrypted_mnemonic = mcrypt.encrypt_str_to_base64(mnemonic);
-    match fs::write(mnemonic_path, encrypted_mnemonic) {
-        Ok(()) => {
-            tracing::info!("Created a new wallet");
-            Ok(())
-        }
-        Err(e) => Err(APIError::FailedKeysCreation(
-            mnemonic_path.to_string_lossy().to_string(),
-            e.to_string(),
-        )),
-    }
+    let encrypted_mnemonic = encrypt_mnemonic(&password, &mnemonic)?;
+    fs::write(mnemonic_path, encrypted_mnemonic).map_err(|e| {
+        APIError::FailedKeysCreation(mnemonic_path.to_string_lossy().to_string(), e.to_string())
+    })
 }
 
 pub(crate) async fn connect_peer_if_necessary(


### PR DESCRIPTION
The mnemonic file now records the scrypt work factors next to the salt, nonce and ciphertext, so they can be raised later without leaving existing files undecryptable. Key derivation and cipher setup are shared with the backup code, whose derived key is unchanged.

Mnemonic files written by previous versions can no longer be read, including those contained in older backups, so affected wallets have to be re-initialized.