### PR TITLE
Shut down on panic or unexpected background processor exit

### DIFF
--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -111,7 +111,7 @@ use crate::swap::SwapData;
 use crate::utils::{
     check_port_is_available, connect_peer_if_necessary, do_connect_peer, get_current_timestamp,
     hex_str, AppState, StaticState, UnlockedAppState, ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST,
-    ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4,
+    ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4, FATAL_ERROR,
 };
 
 pub(crate) const FEE_RATE: u64 = 7;
@@ -2533,7 +2533,7 @@ pub(crate) async fn start_ldk(
 
     // Background Processing
     let (bp_exit, bp_exit_check) = tokio::sync::watch::channel(());
-    let background_processor = tokio::spawn(process_events_async(
+    let bp_fut = process_events_async(
         persister,
         event_handler,
         chain_monitor.clone(),
@@ -2562,7 +2562,21 @@ pub(crate) async fn start_ldk(
                     .unwrap(),
             )
         },
-    ));
+    );
+    let background_processor = tokio::spawn({
+        let stop = Arc::clone(&stop_processing);
+        let cancel = app_state.cancel_token.clone();
+        async move {
+            let res = bp_fut.await;
+            if !stop.load(Ordering::Acquire) {
+                let msg = format!("background processor exited: {res:?}");
+                tracing::error!("{msg}");
+                let _ = FATAL_ERROR.set(msg);
+                cancel.cancel();
+            }
+            res
+        }
+    });
 
     // Regularly reconnect to channel peers.
     let connect_cm = Arc::clone(&channel_manager);

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -111,8 +111,9 @@ use crate::swap::SwapData;
 use crate::utils::{
     check_port_is_available, connect_peer_if_necessary, do_connect_peer, get_current_timestamp,
     hex_str, AppState, StaticState, UnlockedAppState, ELECTRUM_URL_MAINNET, ELECTRUM_URL_REGTEST,
-    ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4, FATAL_ERROR,
+    ELECTRUM_URL_SIGNET, ELECTRUM_URL_TESTNET, ELECTRUM_URL_TESTNET4,
 };
+use crate::FATAL_ERROR;
 
 pub(crate) const FEE_RATE: u64 = 7;
 pub(crate) const UTXO_SIZE_SAT: u32 = 32000;
@@ -2720,9 +2721,11 @@ impl AppState {
             .store(true, Ordering::Release);
         ldk_background_services.peer_manager.disconnect_all_peers();
 
-        // Stop the background processor.
+        // Stop the background processor. Its `bp_exit` receiver lives inside the
+        // `process_events_async` future, so nothing to signal if the background processor is
+        // already gone. Also, send can find no receiver during a panic (racy).
         if !ldk_background_services.bp_exit.is_closed() {
-            ldk_background_services.bp_exit.send(()).unwrap();
+            let _ = ldk_background_services.bp_exit.send(());
             ldk_background_services.background_processor.take()
         } else {
             None
@@ -2734,7 +2737,13 @@ pub(crate) async fn stop_ldk(app_state: Arc<AppState>) {
     tracing::info!("Stopping LDK");
 
     if let Some(join_handle) = app_state.stop_ldk() {
-        join_handle.await.unwrap().unwrap();
+        // this runs while shutting down, possibly because the background processor itself died,
+        // so its outcome is reported instead of unwrapped
+        match join_handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!("Background processor returned an error: {e}"),
+            Err(e) => tracing::error!("Background processor task did not complete: {e}"),
+        }
     }
 
     // connect to the peer port so it can be released
@@ -2749,7 +2758,8 @@ pub(crate) async fn stop_ldk(app_state: Arc<AppState>) {
             break;
         }
         if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 10.0 {
-            panic!("LDK peer port not being released")
+            tracing::error!("LDK peer port {peer_port} was not released within 10s");
+            break;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ use crate::routes::{
     send_btc, send_onion_message, send_payment, send_rgb, shutdown, sign_message, sync, taker,
     unlock,
 };
-use crate::utils::{start_daemon, AppState, LOGS_DIR};
+use crate::utils::{start_daemon, AppState, FATAL_ERROR, LOGS_DIR};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -87,12 +87,26 @@ async fn main() -> Result<()> {
 
     let (router, app_state) = app(args).await?;
 
+    let default_panic_hook = std::panic::take_hook();
+    let cancel_token = app_state.cancel_token.clone();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        tracing::error!("{panic_info}");
+        let _ = FATAL_ERROR.set(panic_info.to_string());
+        cancel_token.cancel();
+        default_panic_hook(panic_info);
+    }));
+
     tracing::info!("Listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown_signal(app_state))
         .await
         .unwrap();
+
+    if let Some(fatal_error) = FATAL_ERROR.get() {
+        tracing::error!("Shutting down due to fatal error: {fatal_error}");
+        std::process::exit(70); // sysexits EX_SOFTWARE
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,11 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use std::{net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant},
+};
 use tokio::signal;
 use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
@@ -57,7 +61,12 @@ use crate::routes::{
     send_btc, send_onion_message, send_payment, send_rgb, shutdown, sign_message, sync, taker,
     unlock,
 };
-use crate::utils::{start_daemon, AppState, FATAL_ERROR, LOGS_DIR};
+use crate::utils::{start_daemon, AppState, LOGS_DIR};
+
+pub(crate) static FATAL_ERROR: OnceLock<String> = OnceLock::new();
+
+// how long a fatal shutdown waits for an in-progress state change (unlock or lock)
+const STATE_CHANGE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -105,6 +114,9 @@ async fn main() -> Result<()> {
 
     if let Some(fatal_error) = FATAL_ERROR.get() {
         tracing::error!("Shutting down due to fatal error: {fatal_error}");
+        // `process::exit` runs no destructors, so the file logger has to be flushed by hand:
+        // dropping the guard waits for the appender to write out what is still buffered
+        drop(_guard);
         std::process::exit(70); // sysexits EX_SOFTWARE
     }
 
@@ -259,11 +271,23 @@ async fn shutdown_signal(app_state: Arc<AppState>) {
     tracing::info!("Received a shutdown signal");
 
     let app_state_copy = app_state.clone();
+    // only a fatal shutdown gives up on an in-progress state change: nobody is waiting for the
+    // node and the exit code still has to be reported, so it cannot wait forever
+    let deadline = FATAL_ERROR
+        .get()
+        .map(|_| Instant::now() + STATE_CHANGE_SHUTDOWN_TIMEOUT);
     loop {
         {
             if app_state_copy.wait_state_change() {
                 break;
             }
+        }
+        if deadline.is_some_and(|deadline| Instant::now() > deadline) {
+            tracing::warn!(
+                "State change did not complete within {}s, shutting down anyway",
+                STATE_CHANGE_SHUTDOWN_TIMEOUT.as_secs()
+            );
+            break;
         }
         tracing::info!("Will shutdown after change state is complete");
         tokio::time::sleep(Duration::from_millis(300)).await;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1552,6 +1552,26 @@ impl AppState {
     }
 }
 
+/// Marks the node as changing state for as long as it is alive.
+///
+/// The flag has to be cleared on every exit path, including an unwind: shutdown waits for the
+/// state change to complete, so a flag left set by a panic would hang the shutdown instead of
+/// letting the node exit.
+struct ChangingStateGuard(Arc<AppState>);
+
+impl ChangingStateGuard {
+    fn new(app_state: Arc<AppState>) -> Self {
+        app_state.update_changing_state(true);
+        Self(app_state)
+    }
+}
+
+impl Drop for ChangingStateGuard {
+    fn drop(&mut self) {
+        self.0.update_changing_state(false);
+    }
+}
+
 pub(crate) async fn address(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<AddressResponse>, APIError> {
@@ -2961,16 +2981,16 @@ pub(crate) async fn lock(
 ) -> Result<Json<EmptyResponse>, APIError> {
     tracing::info!("Lock started");
     no_cancel(async move {
-        match state.check_unlocked().await {
+        let _changing_state = match state.check_unlocked().await {
             Ok(unlocked_state) => {
-                state.update_changing_state(true);
+                let guard = ChangingStateGuard::new(state.clone());
                 drop(unlocked_state);
+                guard
             }
             Err(e) => {
-                state.update_changing_state(false);
                 return Err(e);
             }
-        }
+        };
 
         tracing::debug!("Stopping LDK...");
         stop_ldk(state.clone()).await;
@@ -2979,8 +2999,6 @@ pub(crate) async fn lock(
         state.update_unlocked_app_state(None).await;
 
         state.update_ldk_background_services(None);
-
-        state.update_changing_state(false);
 
         tracing::info!("Lock completed");
         Ok(Json(EmptyResponse {}))
@@ -4239,10 +4257,11 @@ pub(crate) async fn unlock(
 ) -> Result<Json<EmptyResponse>, APIError> {
     tracing::info!("Unlock started");
     no_cancel(async move {
-        match state.check_locked().await {
+        let _changing_state = match state.check_locked().await {
             Ok(unlocked_state) => {
-                state.update_changing_state(true);
+                let guard = ChangingStateGuard::new(state.clone());
                 drop(unlocked_state);
+                guard
             }
             Err(e) => {
                 return Err(match e {
@@ -4250,28 +4269,14 @@ pub(crate) async fn unlock(
                     _ => e,
                 });
             }
-        }
-
-        let mnemonic = match check_password_validity(
-            &payload.password,
-            &state.static_state.storage_dir_path,
-        ) {
-            Ok(mnemonic) => mnemonic,
-            Err(e) => {
-                state.update_changing_state(false);
-                return Err(e);
-            }
         };
+
+        let mnemonic =
+            check_password_validity(&payload.password, &state.static_state.storage_dir_path)?;
 
         tracing::debug!("Starting LDK...");
         let (new_ldk_background_services, new_unlocked_app_state) =
-            match start_ldk(state.clone(), mnemonic, payload).await {
-                Ok((nlbs, nuap)) => (nlbs, nuap),
-                Err(e) => {
-                    state.update_changing_state(false);
-                    return Err(e);
-                }
-            };
+            start_ldk(state.clone(), mnemonic, payload).await?;
         tracing::debug!("LDK started");
 
         state
@@ -4279,8 +4284,6 @@ pub(crate) async fn unlock(
             .await;
 
         state.update_ldk_background_services(Some(new_ldk_background_services));
-
-        state.update_changing_state(false);
 
         tracing::info!("Unlock completed");
         Ok(Json(EmptyResponse {}))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,7 @@ use std::{
     path::Path,
     path::PathBuf,
     str::FromStr,
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard, OnceLock},
     time::{Duration, SystemTime},
 };
 use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
@@ -55,6 +55,8 @@ pub(crate) const ELECTRUM_URL_MAINNET: &str = "ssl://electrum.iriswallet.com:500
 #[cfg(test)]
 pub(crate) const PROXY_ENDPOINT_LOCAL: &str = "rpc://127.0.0.1:3000/json-rpc";
 const PASSWORD_MIN_LENGTH: u8 = 8;
+
+pub(crate) static FATAL_ERROR: OnceLock<String> = OnceLock::new();
 
 pub(crate) struct AppState {
     pub(crate) static_state: Arc<StaticState>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,7 +23,7 @@ use std::{
     path::Path,
     path::PathBuf,
     str::FromStr,
-    sync::{Arc, Mutex, MutexGuard, OnceLock},
+    sync::{Arc, Mutex, MutexGuard},
     time::{Duration, SystemTime},
 };
 use tokio::sync::{Mutex as TokioMutex, MutexGuard as TokioMutexGuard};
@@ -56,8 +56,6 @@ pub(crate) const ELECTRUM_URL_MAINNET: &str = "ssl://electrum.iriswallet.com:500
 pub(crate) const PROXY_ENDPOINT_LOCAL: &str = "rpc://127.0.0.1:3000/json-rpc";
 const PASSWORD_MIN_LENGTH: u8 = 8;
 
-pub(crate) static FATAL_ERROR: OnceLock<String> = OnceLock::new();
-
 pub(crate) struct AppState {
     pub(crate) static_state: Arc<StaticState>,
     pub(crate) cancel_token: CancellationToken,
@@ -70,13 +68,17 @@ pub(crate) struct AppState {
 
 impl AppState {
     pub(crate) fn get_changing_state(&self) -> MutexGuard<'_, bool> {
-        self.changing_state.lock().unwrap()
+        self.changing_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) // propagate the poison
     }
 
     pub(crate) fn get_ldk_background_services(
         &self,
     ) -> MutexGuard<'_, Option<LdkBackgroundServices>> {
-        self.ldk_background_services.lock().unwrap()
+        self.ldk_background_services
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) // propagate the poison
     }
 
     pub(crate) async fn get_unlocked_app_state(
@@ -310,7 +312,10 @@ where
         let result = fut.await;
         let _ = tx.send(result);
     });
-    rx.await.unwrap()
+    // the sender is only dropped without sending if the spawned task panicked, in which case the
+    // panic hook has already logged the cause and started the shutdown
+    rx.await
+        .expect("request task panicked, see the preceding panic for the cause")
 }
 
 pub(crate) fn parse_peer_info(


### PR DESCRIPTION
Follow-up to the discussion in #137. A panic inside the event handler (or any spawned task) kills only that task: `process_events_async` runs in a tokio spawned task whose `JoinHandle` is only awaited at shutdown, so when it dies the HTTP API, peer connections and chain monitoring keep running. The node looks healthy from the outside while event processing and channel manager persistence are dead, and it later exits with code 0.

This PR makes that failure loud, reusing the existing shutdown path:

- a `FATAL_ERROR: OnceLock<String>` in `utils.rs` records the first fatal cause
- the BP spawn is wrapped: if `process_events_async` returns while `stop_processing` was never set, the cause is logged, `FATAL_ERROR` is set and `cancel_token.cancel()` triggers the same graceful teardown as the `/shutdown` API
- a global panic hook installed in `main()` (after `app()`, capturing the cancel token) does the same for panics, which unwind through the await and would skip the wrapper; it chains the default hook to keep backtraces. Since `main()` doesn't run in the test binary, tests are unaffected
- after `axum::serve` returns, `main` exits with code 70 (sysexits `EX_SOFTWARE`) if `FATAL_ERROR` is set, so an orchestrator can tell a crash from an operator stop; this is the only `process::exit`

Note the panic hook intentionally makes a panic in *any* task fatal, not just the BP: the node surviving a crash with no visible change is the dangerous case, and a panic should surface as an incident rather than be absorbed. 

Graceful shutdowns are unchanged: `stop_processing` is set before `bp_exit` is signalled, so the wrapper stays silent and the process still exits 0.