### PR TITLE
Return errors instead of panicking on recoverable wallet failures

### DIFF
--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -789,7 +789,10 @@ impl RgbLibWalletWrapper {
 impl ChangeDestinationSource for RgbLibWalletWrapper {
     fn get_change_destination_script<'a>(&'a self) -> AsyncResult<'a, ScriptBuf, ()> {
         Box::pin(async move {
-            Ok(Address::from_str(&self.get_address().unwrap())
+            let address = self.get_address().map_err(|e| {
+                tracing::error!("cannot get a change address to sweep outputs, will retry: {e}");
+            })?;
+            Ok(Address::from_str(&address)
                 .unwrap()
                 .assume_checked()
                 .script_pubkey())
@@ -802,7 +805,14 @@ impl WalletSource for RgbLibWalletWrapper {
         Box::pin(async move {
             let network: Network = self.bitcoin_network().into();
             let mut wallet = self.wallet.lock().unwrap();
-            Ok(wallet.list_unspents_vanilla(self.online, 1, false).unwrap().iter().filter_map(|u| {
+            let unspents = wallet
+                .list_unspents_vanilla(self.online, 1, false)
+                .map_err(|e| {
+                    tracing::error!(
+                        "cannot list the wallet UTXOs to bump a transaction fee, will retry: {e}"
+                    );
+                })?;
+            Ok(unspents.iter().filter_map(|u| {
             let script = u.txout.script_pubkey.clone().into_boxed_script();
             let address = Address::from_script(&script, network).unwrap();
             let outpoint = OutPoint::from_str(&u.outpoint.to_string()).unwrap();
@@ -837,12 +847,15 @@ impl WalletSource for RgbLibWalletWrapper {
 
     fn get_change_script<'a>(&'a self) -> AsyncResult<'a, ScriptBuf, ()> {
         Box::pin(async move {
-            Ok(
-                Address::from_str(&self.wallet.lock().unwrap().get_address().unwrap())
-                    .unwrap()
-                    .assume_checked()
-                    .script_pubkey(),
-            )
+            let address = self.wallet.lock().unwrap().get_address().map_err(|e| {
+                tracing::error!(
+                    "cannot get a change address to bump a transaction fee, will retry: {e}"
+                );
+            })?;
+            Ok(Address::from_str(&address)
+                .unwrap()
+                .assume_checked()
+                .script_pubkey())
         })
     }
 


### PR DESCRIPTION
Follow-up to #146. The fee-bump path (`WalletSource`/`ChangeDestinationSource`, used by `Event::BumpTransaction` for anchor CPFP after force closes) unwraps wallet operations that can fail for environmental reasons. Since #146 a panic correctly shuts down the whole node, so a transient failure there, e.g. the indexer briefly unreachable during a fee bump, now kills the node and crash-loops it on restart until the dependency recovers, since the event replays.

This converts exactly four calls to log + `Err`, which LDK answers by retrying on the next event/timer tick:

- `list_unspents_vanilla` in `list_confirmed_utxos`: does an indexer network sync plus per-UTXO confirmation lookups (and a DB transaction), the realistic crash-loop trigger
- `get_address` in `get_change_destination_script` and `get_change_script`: writes derivation/backup state through a wallet DB transaction
- `sign_psbt` in `sign_psbt`: goes through the wallet DB, and the wallet's UTXO set can change between `list_confirmed_utxos` and signing

Everything that can only fail on a genuine bug keeps panicking: the `Address`/`OutPoint`/`Psbt` roundtrip parses of wallet-produced data, `extract_tx`, and the mutex locks are untouched.