### PR TITLE
Add TOML config file support with layered CLI overrides and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,6 +4160,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
+ "toml",
  "tower-http",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ thiserror = "2.0"
 time = { version = "0.3.36", features = ["std"] }
 tokio = { version = "1", features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "signal", "sync", "net", "time"] }
 tokio-util = { version = "0.7.12", features = ["codec"] }
+toml = "0.8"
 tower-http = { version = "0.6.1", features = ["cors", "limit", "trace"] }
 tracing = "0.1"
 tracing-appender = "0.2.3"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ specifying:
 - LN peer listening port (`--ldk-peer-listening-port`, default: 9735)
 - network (`--network`, default: testnet)
 
+### Configuration file
+
+The node can be configured via a TOML file, loaded from
+`<storage_directory_path>/config.toml` if it exists, or from the path given
+with `--config <path>`. All settings are optional and documented, along with
+their defaults, in [sample-config.toml](sample-config.toml). Values are
+resolved in order: built-in defaults, then the config file, then explicit CLI
+options. Invalid values and unknown keys abort startup with an error.
+
 ### Regtest
 
 To easily start the required services on a regtest network, run:

--- a/sample-config.toml
+++ b/sample-config.toml
@@ -1,0 +1,94 @@
+# Sample configuration file for rgb-lightning-node.
+#
+# The node loads <storage_directory_path>/config.toml if it exists, or the
+# file given via --config. Values here override the built-in defaults and are
+# overridden by explicit CLI options. All keys are optional; unknown keys are
+# rejected. The values below document the defaults.
+
+[auth]
+# Disable biscuit token authentication
+#disable_authentication = false
+# Minimum accepted wallet password length
+#password_min_length = 8
+# Root public key for biscuit token authentication (hex-encoded)
+#root_public_key = ""
+
+[chain]
+# Interval between fee estimate refreshes (seconds)
+#fee_refresh_interval_secs = 60
+
+[channels]
+# Forward HTLCs to private (unannounced) channels
+#accept_forwards_to_priv_channels = false
+# CLTV expiry delta advertised for forwarded HTLCs (min 48)
+#cltv_expiry_delta = 72
+# Minimum inbound payment amount (msat)
+#dust_limit_msat = 546000
+# Default forwarding base fee for new channels (msat)
+#forwarding_fee_base_msat = 1000
+# Default forwarding proportional fee for new channels (parts per million)
+#forwarding_fee_proportional_millionths = 0
+# Minimum HTLC amount on RGB channels (msat, must clear HTLC dust so asset payments can settle)
+#htlc_min_msat = 3000000
+# Max dust HTLC exposure as a fixed msat limit (mutually exclusive with the multiplier variant)
+#max_dust_htlc_exposure_fixed_msat = 5000000
+# Max dust HTLC exposure as a multiplier on the max fee estimate (mutually exclusive with the fixed variant)
+#max_dust_htlc_exposure_multiplier = 10000
+# Max inbound HTLC value in flight, percent of channel capacity (1-100)
+#max_inbound_htlc_value_in_flight_percent = 10
+# Max confirmations a peer may require before a channel is usable
+#max_minimum_depth = 144
+# Maximum channel capacity (sat, protocol limit 16777215)
+#open_max_sat = 16777215
+# Minimum RGB asset amount in a channel
+#open_min_rgb_amount = 1
+# Minimum capacity for a vanilla channel (sat)
+#open_min_sat = 5506
+# Max concurrent HTLCs we accept per channel (1-483)
+#our_max_accepted_htlcs = 50
+# to_self_delay we require from the counterparty (144-2016)
+#our_to_self_delay = 144
+# Maximum to_self_delay accepted from the counterparty (max 2016)
+#their_to_self_delay = 2016
+
+[media]
+# Max aggregate size of RGB media accepted over p2p per channel-open (MB)
+#max_aggregated_media_size_per_channel_mb = 24
+# Max number of RGB media files accepted over p2p per channel-open
+#max_media_files_per_channel = 42
+# Max allowed media size for upload (MB)
+#max_media_upload_size_mb = 5
+# Max number of pending channel-open consignments buffered over p2p at once
+#max_pending_consignments = 10
+
+[node]
+# Delay before the first node announcement broadcast (seconds)
+#announce_initial_delay_secs = 60
+# Interval between node announcement refreshes (seconds)
+#announce_refresh_interval_secs = 3600
+# Listening port of the daemon
+#daemon_listening_port = 3001
+# Listening port for LN peers
+#ldk_peer_listening_port = 9735
+# Bitcoin network (Mainnet, Testnet, Testnet4, Signet, Regtest)
+#network = "Testnet"
+# Interval between channel peer reconnection attempts (seconds)
+#peer_reconnect_interval_secs = 1
+
+[payments]
+# Final CLTV expiry delta used for payments
+#final_cltv_expiry_delta = 14
+# Maximum acceptable total swap fee (msat)
+#max_swap_fee_msat = 3000000
+# Payment retry timeout in seconds
+#retry_timeout_secs = 10
+
+[rgb]
+# Default fee rate in sat/vB for coloring, witness and channel funding txs
+#fee_rate_sat_vb = 7
+# Confirmations required for channel funding transactions
+#min_channel_confirmations = 6
+# Default number of UTXOs created by /createutxos
+#utxo_num = 4
+# Default size in sats for colorable UTXOs created by /createutxos
+#utxo_size_sat = 32000

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,8 +1,10 @@
-use clap::{value_parser, Parser};
+use clap::parser::ValueSource;
+use clap::{value_parser, ArgMatches, CommandFactory, FromArgMatches, Parser};
 use rgb_lib::BitcoinNetwork;
 use std::path::PathBuf;
 
 use crate::auth::check_auth_args;
+use crate::config::{load_config_file, Config, TomlConfig, DEFAULT_CONFIG_FILENAME};
 use crate::error::AppError;
 use crate::utils::check_port_is_available;
 
@@ -11,6 +13,10 @@ use crate::utils::check_port_is_available;
 struct Args {
     /// Path for the node storage directory
     storage_directory_path: PathBuf,
+
+    /// Path to the TOML configuration file.
+    #[arg(long)]
+    config: Option<PathBuf>,
 
     /// Listening port of the daemon
     #[arg(long, default_value_t = 3001)]
@@ -59,29 +65,240 @@ pub(crate) struct UserArgs {
     pub(crate) max_pending_consignments: usize,
     pub(crate) max_media_files_per_channel: usize,
     pub(crate) root_public_key: Option<biscuit_auth::PublicKey>,
+    pub(crate) config: Config,
 }
 
 pub(crate) fn parse_startup_args() -> Result<UserArgs, AppError> {
-    let args = Args::parse();
+    let matches = Args::command().get_matches();
+    let args =
+        Args::from_arg_matches(&matches).map_err(|e| AppError::InvalidConfig(e.to_string()))?;
+    let toml = load_startup_toml(&args)?;
+    let user_args = resolve_user_args(args, &matches, toml)?;
 
-    let network = args.network;
+    check_port_is_available(user_args.daemon_listening_port)?;
+    check_port_is_available(user_args.ldk_peer_listening_port)?;
 
-    let daemon_listening_port = args.daemon_listening_port;
-    check_port_is_available(daemon_listening_port)?;
-    let ldk_peer_listening_port = args.ldk_peer_listening_port;
-    check_port_is_available(ldk_peer_listening_port)?;
+    Ok(user_args)
+}
 
-    let root_public_key = check_auth_args(args.disable_authentication, args.root_public_key)?;
+fn load_startup_toml(args: &Args) -> Result<TomlConfig, AppError> {
+    if let Some(path) = &args.config {
+        return load_config_file(path);
+    }
+    let default_path = args.storage_directory_path.join(DEFAULT_CONFIG_FILENAME);
+    if default_path.exists() {
+        load_config_file(&default_path)
+    } else {
+        Ok(TomlConfig::default())
+    }
+}
+
+/// Merge the three configuration layers: built-in defaults, then the config
+/// file, then explicit CLI options.
+fn resolve_user_args(
+    args: Args,
+    matches: &ArgMatches,
+    toml: TomlConfig,
+) -> Result<UserArgs, AppError> {
+    let config = Config::from_toml(&toml)?;
+    let from_cli = |name: &str| matches.value_source(name) == Some(ValueSource::CommandLine);
+
+    let node = toml.node.unwrap_or_default();
+    let auth = toml.auth.unwrap_or_default();
+    let media = toml.media.unwrap_or_default();
+
+    let network = match node.network {
+        Some(ref s) if !from_cli("network") => s
+            .parse::<BitcoinNetwork>()
+            .map_err(|_| AppError::InvalidConfig(format!("invalid node.network: {s}")))?,
+        _ => args.network,
+    };
+
+    let daemon_listening_port = if from_cli("daemon_listening_port") {
+        args.daemon_listening_port
+    } else {
+        node.daemon_listening_port
+            .unwrap_or(args.daemon_listening_port)
+    };
+    let ldk_peer_listening_port = if from_cli("ldk_peer_listening_port") {
+        args.ldk_peer_listening_port
+    } else {
+        node.ldk_peer_listening_port
+            .unwrap_or(args.ldk_peer_listening_port)
+    };
+    if daemon_listening_port == ldk_peer_listening_port {
+        return Err(AppError::InvalidConfig(format!(
+            "daemon_listening_port and ldk_peer_listening_port cannot both be {daemon_listening_port}"
+        )));
+    }
+
+    let max_media_upload_size_mb = if from_cli("max_media_upload_size_mb") {
+        args.max_media_upload_size_mb
+    } else {
+        media
+            .max_media_upload_size_mb
+            .unwrap_or(args.max_media_upload_size_mb)
+    };
+    let max_aggregated_media_size_per_channel_mb =
+        if from_cli("max_aggregated_media_size_per_channel_mb") {
+            args.max_aggregated_media_size_per_channel_mb
+        } else {
+            media
+                .max_aggregated_media_size_per_channel_mb
+                .unwrap_or(args.max_aggregated_media_size_per_channel_mb)
+        };
+    let max_pending_consignments = if from_cli("max_pending_consignments") {
+        args.max_pending_consignments
+    } else {
+        media
+            .max_pending_consignments
+            .unwrap_or(args.max_pending_consignments)
+    };
+    let max_media_files_per_channel = if from_cli("max_media_files_per_channel") {
+        args.max_media_files_per_channel
+    } else {
+        media
+            .max_media_files_per_channel
+            .unwrap_or(args.max_media_files_per_channel)
+    };
+
+    let disable_authentication =
+        args.disable_authentication || auth.disable_authentication.unwrap_or(false);
+    let root_public_key_hex = args.root_public_key.or(auth.root_public_key);
+    let root_public_key = check_auth_args(disable_authentication, root_public_key_hex)?;
 
     Ok(UserArgs {
         storage_dir_path: args.storage_directory_path,
         daemon_listening_port,
         ldk_peer_listening_port,
         network,
-        max_media_upload_size_mb: args.max_media_upload_size_mb,
-        max_aggregated_media_size_per_channel_mb: args.max_aggregated_media_size_per_channel_mb,
-        max_pending_consignments: args.max_pending_consignments,
-        max_media_files_per_channel: args.max_media_files_per_channel,
+        max_media_upload_size_mb,
+        max_aggregated_media_size_per_channel_mb,
+        max_pending_consignments,
+        max_media_files_per_channel,
         root_public_key,
+        config,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TomlConfig;
+
+    const PUBKEY: &str = "02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619";
+
+    fn resolve(argv: &[&str], toml: &str) -> Result<UserArgs, AppError> {
+        let matches = <Args as clap::CommandFactory>::command()
+            .try_get_matches_from(argv)
+            .unwrap();
+        let args = <Args as clap::FromArgMatches>::from_arg_matches(&matches).unwrap();
+        resolve_user_args(args, &matches, TomlConfig::parse(toml).unwrap())
+    }
+
+    fn base(extra: &[&str]) -> Vec<&'static str> {
+        let mut argv = vec!["rln", "/tmp/storage", "--disable-authentication"];
+        argv.extend(
+            extra
+                .iter()
+                .map(|s| -> &'static str { Box::leak(s.to_string().into_boxed_str()) }),
+        );
+        argv
+    }
+
+    #[test]
+    fn defaults_without_file_or_flags() {
+        let ua = resolve(&base(&[]), "").unwrap();
+        assert_eq!(ua.daemon_listening_port, 3001);
+        assert_eq!(ua.ldk_peer_listening_port, 9735);
+        assert_eq!(ua.network, BitcoinNetwork::Testnet);
+        assert_eq!(ua.max_media_upload_size_mb, 5);
+        assert_eq!(ua.max_aggregated_media_size_per_channel_mb, 24);
+        assert_eq!(ua.max_pending_consignments, 10);
+        assert_eq!(ua.max_media_files_per_channel, 42);
+        assert_eq!(ua.config, crate::config::Config::default());
+    }
+
+    #[test]
+    fn file_overrides_defaults() {
+        let ua = resolve(
+            &base(&[]),
+            "[node]\nnetwork = \"regtest\"\ndaemon_listening_port = 8888\nldk_peer_listening_port = 9999\n\n[media]\nmax_media_upload_size_mb = 10\nmax_pending_consignments = 20\n",
+        )
+        .unwrap();
+        assert_eq!(ua.network, BitcoinNetwork::Regtest);
+        assert_eq!(ua.daemon_listening_port, 8888);
+        assert_eq!(ua.ldk_peer_listening_port, 9999);
+        assert_eq!(ua.max_media_upload_size_mb, 10);
+        assert_eq!(ua.max_pending_consignments, 20);
+    }
+
+    #[test]
+    fn cli_overrides_file() {
+        let ua = resolve(
+            &base(&[
+                "--daemon-listening-port",
+                "9999",
+                "--network",
+                "signet",
+                "--max-media-upload-size-mb",
+                "7",
+            ]),
+            "[node]\nnetwork = \"regtest\"\ndaemon_listening_port = 8888\n\n[media]\nmax_media_upload_size_mb = 10\n",
+        )
+        .unwrap();
+        assert_eq!(ua.daemon_listening_port, 9999);
+        assert_eq!(ua.network, BitcoinNetwork::Signet);
+        assert_eq!(ua.max_media_upload_size_mb, 7);
+    }
+
+    #[test]
+    fn invalid_network_in_file_rejected() {
+        let res = resolve(&base(&[]), "[node]\nnetwork = \"bogus\"\n");
+        assert!(matches!(res, Err(AppError::InvalidConfig(ref m)) if m.contains("bogus")));
+    }
+
+    #[test]
+    fn same_ports_rejected() {
+        let res = resolve(
+            &base(&[]),
+            "[node]\ndaemon_listening_port = 4000\nldk_peer_listening_port = 4000\n",
+        );
+        assert!(matches!(res, Err(AppError::InvalidConfig(_))));
+    }
+
+    #[test]
+    fn auth_from_file() {
+        let argv = vec!["rln", "/tmp/storage"];
+        let ua = resolve(&argv, "[auth]\ndisable_authentication = true\n").unwrap();
+        assert!(ua.root_public_key.is_none());
+    }
+
+    #[test]
+    fn auth_conflict_rejected() {
+        let res = resolve(
+            &base(&[]),
+            &format!("[auth]\nroot_public_key = \"{PUBKEY}\"\n"),
+        );
+        assert!(matches!(res, Err(AppError::InvalidAuthenticationArgs)));
+    }
+
+    #[test]
+    fn missing_auth_rejected() {
+        let argv = vec!["rln", "/tmp/storage"];
+        let res = resolve(&argv, "");
+        assert!(matches!(res, Err(AppError::InvalidAuthenticationArgs)));
+    }
+
+    #[test]
+    fn policy_sections_attached_to_user_args() {
+        let ua = resolve(&base(&[]), "[rgb]\nfee_rate_sat_vb = 12\n").unwrap();
+        assert_eq!(ua.config.rgb.fee_rate_sat_vb, 12);
+    }
+
+    #[test]
+    fn invalid_policy_in_file_rejected() {
+        let res = resolve(&base(&[]), "[rgb]\nfee_rate_sat_vb = 0\n");
+        assert!(matches!(res, Err(AppError::InvalidConfig(_))));
+    }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1,0 +1,108 @@
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::AppError;
+
+/// Mirror of the TOML config file. Every field is optional: absent keys keep
+/// the built-in defaults, unknown keys are hard errors.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlConfig {
+    pub(crate) auth: Option<TomlAuth>,
+    pub(crate) chain: Option<TomlChain>,
+    pub(crate) channels: Option<TomlChannels>,
+    pub(crate) media: Option<TomlMedia>,
+    pub(crate) node: Option<TomlNode>,
+    pub(crate) payments: Option<TomlPayments>,
+    pub(crate) rgb: Option<TomlRgb>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlAuth {
+    pub(crate) disable_authentication: Option<bool>,
+    pub(crate) password_min_length: Option<u8>,
+    pub(crate) root_public_key: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlChain {
+    pub(crate) fee_refresh_interval_secs: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlChannels {
+    pub(crate) accept_forwards_to_priv_channels: Option<bool>,
+    pub(crate) cltv_expiry_delta: Option<u16>,
+    pub(crate) dust_limit_msat: Option<u64>,
+    pub(crate) forwarding_fee_base_msat: Option<u32>,
+    pub(crate) forwarding_fee_proportional_millionths: Option<u32>,
+    pub(crate) htlc_min_msat: Option<u64>,
+    pub(crate) max_dust_htlc_exposure_fixed_msat: Option<u64>,
+    pub(crate) max_dust_htlc_exposure_multiplier: Option<u64>,
+    pub(crate) max_inbound_htlc_value_in_flight_percent: Option<u8>,
+    pub(crate) max_minimum_depth: Option<u32>,
+    pub(crate) open_max_sat: Option<u64>,
+    pub(crate) open_min_rgb_amount: Option<u64>,
+    pub(crate) open_min_sat: Option<u64>,
+    pub(crate) our_max_accepted_htlcs: Option<u16>,
+    pub(crate) our_to_self_delay: Option<u16>,
+    pub(crate) their_to_self_delay: Option<u16>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlMedia {
+    pub(crate) max_aggregated_media_size_per_channel_mb: Option<u16>,
+    pub(crate) max_media_files_per_channel: Option<usize>,
+    pub(crate) max_media_upload_size_mb: Option<u16>,
+    pub(crate) max_pending_consignments: Option<usize>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlNode {
+    pub(crate) announce_initial_delay_secs: Option<u64>,
+    pub(crate) announce_refresh_interval_secs: Option<u64>,
+    pub(crate) daemon_listening_port: Option<u16>,
+    pub(crate) ldk_peer_listening_port: Option<u16>,
+    pub(crate) network: Option<String>,
+    pub(crate) peer_reconnect_interval_secs: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlPayments {
+    pub(crate) final_cltv_expiry_delta: Option<u32>,
+    pub(crate) max_swap_fee_msat: Option<u64>,
+    pub(crate) retry_timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TomlRgb {
+    pub(crate) fee_rate_sat_vb: Option<u64>,
+    pub(crate) min_channel_confirmations: Option<u8>,
+    pub(crate) utxo_num: Option<u8>,
+    pub(crate) utxo_size_sat: Option<u32>,
+}
+
+impl TomlConfig {
+    pub(crate) fn parse(content: &str) -> Result<Self, AppError> {
+        toml::from_str(content).map_err(|e| AppError::InvalidConfig(e.to_string()))
+    }
+}
+
+pub(crate) fn load_config_file(path: &Path) -> Result<TomlConfig, AppError> {
+    let content = fs::read_to_string(path).map_err(|e| {
+        AppError::InvalidConfig(format!("cannot read config file {}: {e}", path.display()))
+    })?;
+    TomlConfig::parse(&content).map_err(|e| match e {
+        AppError::InvalidConfig(m) => AppError::InvalidConfig(format!("{}: {m}", path.display())),
+        other => other,
+    })
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,471 @@
+mod file;
+#[cfg(test)]
+mod tests;
+
+pub(crate) use file::{load_config_file, TomlConfig};
+
+use lightning::ln::channelmanager::{BREAKDOWN_TIMEOUT, MIN_CLTV_EXPIRY_DELTA};
+use lightning::util::config::{
+    ChannelConfig as LdkChannelConfig, ChannelHandshakeConfig as LdkChannelHandshakeConfig,
+    ChannelHandshakeLimits as LdkChannelHandshakeLimits, MaxDustHTLCExposure,
+};
+
+use crate::error::AppError;
+use crate::ldk::{FEE_RATE, MIN_CHANNEL_CONFIRMATIONS, UTXO_SIZE_SAT};
+use crate::routes::{DEFAULT_FINAL_CLTV_EXPIRY_DELTA, DUST_LIMIT_MSAT, HTLC_MIN_MSAT};
+
+pub(crate) const DEFAULT_CONFIG_FILENAME: &str = "config.toml";
+
+const DEFAULT_ANNOUNCE_INITIAL_DELAY_SECS: u64 = 60;
+const DEFAULT_ANNOUNCE_REFRESH_INTERVAL_SECS: u64 = 3600;
+const DEFAULT_FEE_REFRESH_INTERVAL_SECS: u64 = 60;
+const DEFAULT_MAX_SWAP_FEE_MSAT: u64 = 3_000_000;
+const DEFAULT_OPENCHANNEL_MAX_SAT: u64 = 16_777_215;
+const DEFAULT_OPENCHANNEL_MIN_RGB_AMT: u64 = 1;
+const DEFAULT_OPENCHANNEL_MIN_SAT: u64 = 5506;
+const DEFAULT_PASSWORD_MIN_LENGTH: u8 = 8;
+const DEFAULT_PAYMENT_RETRY_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_PEER_RECONNECT_INTERVAL_SECS: u64 = 1;
+// lnd's max to_self_delay is 2016, so we want to be compatible
+const DEFAULT_THEIR_TO_SELF_DELAY: u16 = 2016;
+const DEFAULT_UTXO_NUM: u8 = 4;
+
+// BOLT-2 maximum for max_accepted_htlcs (LDK silently clamps higher values)
+const MAX_ACCEPTED_HTLCS_CAP: u16 = 483;
+const MAX_CHANNEL_SAT: u64 = 16_777_215;
+const MAX_TO_SELF_DELAY: u16 = 2016;
+
+/// Node settings resolved from built-in defaults overridden by the optional
+/// TOML config file. With no config file every value matches the historical
+/// hardcoded behavior.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct Config {
+    pub(crate) auth: AuthSection,
+    pub(crate) chain: ChainSection,
+    pub(crate) channels: ChannelsSection,
+    pub(crate) node: NodeSection,
+    pub(crate) payments: PaymentsSection,
+    pub(crate) rgb: RgbSection,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct AuthSection {
+    pub(crate) password_min_length: u8,
+}
+
+impl Default for AuthSection {
+    fn default() -> Self {
+        Self {
+            password_min_length: DEFAULT_PASSWORD_MIN_LENGTH,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ChainSection {
+    pub(crate) fee_refresh_interval_secs: u64,
+}
+
+impl Default for ChainSection {
+    fn default() -> Self {
+        Self {
+            fee_refresh_interval_secs: DEFAULT_FEE_REFRESH_INTERVAL_SECS,
+        }
+    }
+}
+
+/// Maximum dust HTLC exposure, mirroring LDK's `MaxDustHTLCExposure`.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum DustExposure {
+    FeeRateMultiplier(u64),
+    FixedLimitMsat(u64),
+}
+
+impl DustExposure {
+    fn from_ldk(value: MaxDustHTLCExposure) -> Self {
+        match value {
+            MaxDustHTLCExposure::FeeRateMultiplier(m) => Self::FeeRateMultiplier(m),
+            MaxDustHTLCExposure::FixedLimitMsat(m) => Self::FixedLimitMsat(m),
+        }
+    }
+
+    fn to_ldk(&self) -> MaxDustHTLCExposure {
+        match self {
+            Self::FeeRateMultiplier(m) => MaxDustHTLCExposure::FeeRateMultiplier(*m),
+            Self::FixedLimitMsat(m) => MaxDustHTLCExposure::FixedLimitMsat(*m),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ChannelsSection {
+    pub(crate) accept_forwards_to_priv_channels: bool,
+    pub(crate) cltv_expiry_delta: u16,
+    pub(crate) dust_limit_msat: u64,
+    pub(crate) forwarding_fee_base_msat: u32,
+    pub(crate) forwarding_fee_proportional_millionths: u32,
+    pub(crate) htlc_min_msat: u64,
+    pub(crate) max_dust_htlc_exposure: DustExposure,
+    pub(crate) max_inbound_htlc_value_in_flight_percent: u8,
+    pub(crate) max_minimum_depth: u32,
+    pub(crate) open_max_sat: u64,
+    pub(crate) open_min_rgb_amount: u64,
+    pub(crate) open_min_sat: u64,
+    pub(crate) our_max_accepted_htlcs: u16,
+    pub(crate) our_to_self_delay: u16,
+    pub(crate) their_to_self_delay: u16,
+}
+
+impl Default for ChannelsSection {
+    fn default() -> Self {
+        // LDK-inherited defaults are sourced from LDK itself so they track the fork
+        let ldk_channel = LdkChannelConfig::default();
+        let ldk_handshake = LdkChannelHandshakeConfig::default();
+        let ldk_limits = LdkChannelHandshakeLimits::default();
+        Self {
+            accept_forwards_to_priv_channels: false,
+            cltv_expiry_delta: ldk_channel.cltv_expiry_delta,
+            dust_limit_msat: DUST_LIMIT_MSAT,
+            forwarding_fee_base_msat: ldk_channel.forwarding_fee_base_msat,
+            forwarding_fee_proportional_millionths: ldk_channel
+                .forwarding_fee_proportional_millionths,
+            htlc_min_msat: HTLC_MIN_MSAT,
+            max_dust_htlc_exposure: DustExposure::from_ldk(ldk_channel.max_dust_htlc_exposure),
+            max_inbound_htlc_value_in_flight_percent: ldk_handshake
+                .max_inbound_htlc_value_in_flight_percent_of_channel,
+            max_minimum_depth: ldk_limits.max_minimum_depth,
+            open_max_sat: DEFAULT_OPENCHANNEL_MAX_SAT,
+            open_min_rgb_amount: DEFAULT_OPENCHANNEL_MIN_RGB_AMT,
+            open_min_sat: DEFAULT_OPENCHANNEL_MIN_SAT,
+            our_max_accepted_htlcs: ldk_handshake.our_max_accepted_htlcs,
+            our_to_self_delay: ldk_handshake.our_to_self_delay,
+            their_to_self_delay: DEFAULT_THEIR_TO_SELF_DELAY,
+        }
+    }
+}
+
+impl ChannelsSection {
+    /// LDK per-channel config with the configured forwarding values applied.
+    pub(crate) fn channel_config(&self) -> LdkChannelConfig {
+        LdkChannelConfig {
+            forwarding_fee_proportional_millionths: self.forwarding_fee_proportional_millionths,
+            forwarding_fee_base_msat: self.forwarding_fee_base_msat,
+            cltv_expiry_delta: self.cltv_expiry_delta,
+            max_dust_htlc_exposure: self.max_dust_htlc_exposure.to_ldk(),
+            ..Default::default()
+        }
+    }
+
+    /// Minimum capacity for an RGB channel, derived from the HTLC minimum.
+    pub(crate) fn open_rgb_min_sat(&self) -> u64 {
+        self.htlc_min_msat / 1000 * 10 + 10
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct NodeSection {
+    pub(crate) announce_initial_delay_secs: u64,
+    pub(crate) announce_refresh_interval_secs: u64,
+    pub(crate) peer_reconnect_interval_secs: u64,
+}
+
+impl Default for NodeSection {
+    fn default() -> Self {
+        Self {
+            announce_initial_delay_secs: DEFAULT_ANNOUNCE_INITIAL_DELAY_SECS,
+            announce_refresh_interval_secs: DEFAULT_ANNOUNCE_REFRESH_INTERVAL_SECS,
+            peer_reconnect_interval_secs: DEFAULT_PEER_RECONNECT_INTERVAL_SECS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct PaymentsSection {
+    pub(crate) final_cltv_expiry_delta: u32,
+    pub(crate) max_swap_fee_msat: u64,
+    pub(crate) retry_timeout_secs: u64,
+}
+
+impl Default for PaymentsSection {
+    fn default() -> Self {
+        Self {
+            final_cltv_expiry_delta: DEFAULT_FINAL_CLTV_EXPIRY_DELTA,
+            max_swap_fee_msat: DEFAULT_MAX_SWAP_FEE_MSAT,
+            retry_timeout_secs: DEFAULT_PAYMENT_RETRY_TIMEOUT_SECS,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct RgbSection {
+    pub(crate) fee_rate_sat_vb: u64,
+    pub(crate) min_channel_confirmations: u8,
+    pub(crate) utxo_num: u8,
+    pub(crate) utxo_size_sat: u32,
+}
+
+impl Default for RgbSection {
+    fn default() -> Self {
+        Self {
+            fee_rate_sat_vb: FEE_RATE,
+            min_channel_confirmations: MIN_CHANNEL_CONFIRMATIONS,
+            utxo_num: DEFAULT_UTXO_NUM,
+            utxo_size_sat: UTXO_SIZE_SAT,
+        }
+    }
+}
+
+fn invalid(msg: String) -> AppError {
+    AppError::InvalidConfig(msg)
+}
+
+impl Config {
+    /// Overlay the file values on the defaults and validate the result.
+    pub(crate) fn from_toml(toml: &TomlConfig) -> Result<Self, AppError> {
+        if let Some(channels) = &toml.channels {
+            if channels.max_dust_htlc_exposure_multiplier.is_some()
+                && channels.max_dust_htlc_exposure_fixed_msat.is_some()
+            {
+                return Err(invalid(
+                    "channels.max_dust_htlc_exposure_multiplier and \
+                     channels.max_dust_htlc_exposure_fixed_msat are mutually exclusive"
+                        .to_string(),
+                ));
+            }
+        }
+        let mut config = Config::default();
+        config.apply_toml(toml);
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn apply_toml(&mut self, toml: &TomlConfig) {
+        if let Some(auth) = &toml.auth {
+            apply(&mut self.auth.password_min_length, auth.password_min_length);
+        }
+        if let Some(chain) = &toml.chain {
+            apply(
+                &mut self.chain.fee_refresh_interval_secs,
+                chain.fee_refresh_interval_secs,
+            );
+        }
+        if let Some(channels) = &toml.channels {
+            apply(
+                &mut self.channels.accept_forwards_to_priv_channels,
+                channels.accept_forwards_to_priv_channels,
+            );
+            apply(
+                &mut self.channels.cltv_expiry_delta,
+                channels.cltv_expiry_delta,
+            );
+            apply(&mut self.channels.dust_limit_msat, channels.dust_limit_msat);
+            apply(
+                &mut self.channels.forwarding_fee_base_msat,
+                channels.forwarding_fee_base_msat,
+            );
+            apply(
+                &mut self.channels.forwarding_fee_proportional_millionths,
+                channels.forwarding_fee_proportional_millionths,
+            );
+            apply(&mut self.channels.htlc_min_msat, channels.htlc_min_msat);
+            if let Some(fixed_msat) = channels.max_dust_htlc_exposure_fixed_msat {
+                self.channels.max_dust_htlc_exposure = DustExposure::FixedLimitMsat(fixed_msat);
+            }
+            if let Some(multiplier) = channels.max_dust_htlc_exposure_multiplier {
+                self.channels.max_dust_htlc_exposure = DustExposure::FeeRateMultiplier(multiplier);
+            }
+            apply(
+                &mut self.channels.max_inbound_htlc_value_in_flight_percent,
+                channels.max_inbound_htlc_value_in_flight_percent,
+            );
+            apply(
+                &mut self.channels.max_minimum_depth,
+                channels.max_minimum_depth,
+            );
+            apply(&mut self.channels.open_max_sat, channels.open_max_sat);
+            apply(
+                &mut self.channels.open_min_rgb_amount,
+                channels.open_min_rgb_amount,
+            );
+            apply(&mut self.channels.open_min_sat, channels.open_min_sat);
+            apply(
+                &mut self.channels.our_max_accepted_htlcs,
+                channels.our_max_accepted_htlcs,
+            );
+            apply(
+                &mut self.channels.our_to_self_delay,
+                channels.our_to_self_delay,
+            );
+            apply(
+                &mut self.channels.their_to_self_delay,
+                channels.their_to_self_delay,
+            );
+        }
+        if let Some(node) = &toml.node {
+            apply(
+                &mut self.node.announce_initial_delay_secs,
+                node.announce_initial_delay_secs,
+            );
+            apply(
+                &mut self.node.announce_refresh_interval_secs,
+                node.announce_refresh_interval_secs,
+            );
+            apply(
+                &mut self.node.peer_reconnect_interval_secs,
+                node.peer_reconnect_interval_secs,
+            );
+        }
+        if let Some(payments) = &toml.payments {
+            apply(
+                &mut self.payments.final_cltv_expiry_delta,
+                payments.final_cltv_expiry_delta,
+            );
+            apply(
+                &mut self.payments.max_swap_fee_msat,
+                payments.max_swap_fee_msat,
+            );
+            apply(
+                &mut self.payments.retry_timeout_secs,
+                payments.retry_timeout_secs,
+            );
+        }
+        if let Some(rgb) = &toml.rgb {
+            apply(&mut self.rgb.fee_rate_sat_vb, rgb.fee_rate_sat_vb);
+            apply(
+                &mut self.rgb.min_channel_confirmations,
+                rgb.min_channel_confirmations,
+            );
+            apply(&mut self.rgb.utxo_num, rgb.utxo_num);
+            apply(&mut self.rgb.utxo_size_sat, rgb.utxo_size_sat);
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), AppError> {
+        nonzero(
+            self.auth.password_min_length as u64,
+            "auth.password_min_length",
+        )?;
+        nonzero(
+            self.chain.fee_refresh_interval_secs,
+            "chain.fee_refresh_interval_secs",
+        )?;
+        if self.channels.cltv_expiry_delta < MIN_CLTV_EXPIRY_DELTA {
+            return Err(invalid(format!(
+                "channels.cltv_expiry_delta must be at least {MIN_CLTV_EXPIRY_DELTA}"
+            )));
+        }
+        nonzero(self.channels.dust_limit_msat, "channels.dust_limit_msat")?;
+        nonzero(self.channels.htlc_min_msat, "channels.htlc_min_msat")?;
+        match self.channels.max_dust_htlc_exposure {
+            DustExposure::FeeRateMultiplier(0) => {
+                return Err(invalid(
+                    "channels.max_dust_htlc_exposure_multiplier must be greater than 0".to_string(),
+                ));
+            }
+            DustExposure::FixedLimitMsat(0) => {
+                return Err(invalid(
+                    "channels.max_dust_htlc_exposure_fixed_msat must be greater than 0".to_string(),
+                ));
+            }
+            _ => {}
+        }
+        if self.channels.max_inbound_htlc_value_in_flight_percent == 0
+            || self.channels.max_inbound_htlc_value_in_flight_percent > 100
+        {
+            return Err(invalid(
+                "channels.max_inbound_htlc_value_in_flight_percent must be between 1 and 100"
+                    .to_string(),
+            ));
+        }
+        nonzero(
+            self.channels.max_minimum_depth as u64,
+            "channels.max_minimum_depth",
+        )?;
+        if self.channels.open_max_sat > MAX_CHANNEL_SAT {
+            return Err(invalid(format!(
+                "channels.open_max_sat cannot exceed the protocol limit of {MAX_CHANNEL_SAT} sats"
+            )));
+        }
+        nonzero(
+            self.channels.open_min_rgb_amount,
+            "channels.open_min_rgb_amount",
+        )?;
+        nonzero(self.channels.open_min_sat, "channels.open_min_sat")?;
+        if self.channels.open_min_sat > self.channels.open_max_sat {
+            return Err(invalid(format!(
+                "channels.open_min_sat ({}) cannot exceed channels.open_max_sat ({})",
+                self.channels.open_min_sat, self.channels.open_max_sat
+            )));
+        }
+        if self.channels.open_rgb_min_sat() > self.channels.open_max_sat {
+            return Err(invalid(format!(
+                "the RGB channel minimum derived from channels.htlc_min_msat ({} sats) \
+                 cannot exceed channels.open_max_sat ({})",
+                self.channels.open_rgb_min_sat(),
+                self.channels.open_max_sat
+            )));
+        }
+        if self.channels.our_max_accepted_htlcs == 0
+            || self.channels.our_max_accepted_htlcs > MAX_ACCEPTED_HTLCS_CAP
+        {
+            return Err(invalid(format!(
+                "channels.our_max_accepted_htlcs must be between 1 and {MAX_ACCEPTED_HTLCS_CAP}"
+            )));
+        }
+        if self.channels.our_to_self_delay < BREAKDOWN_TIMEOUT
+            || self.channels.our_to_self_delay > MAX_TO_SELF_DELAY
+        {
+            return Err(invalid(format!(
+                "channels.our_to_self_delay must be between {BREAKDOWN_TIMEOUT} and {MAX_TO_SELF_DELAY}"
+            )));
+        }
+        if self.channels.their_to_self_delay == 0
+            || self.channels.their_to_self_delay > MAX_TO_SELF_DELAY
+        {
+            return Err(invalid(format!(
+                "channels.their_to_self_delay must be between 1 and {MAX_TO_SELF_DELAY}"
+            )));
+        }
+        nonzero(
+            self.node.announce_refresh_interval_secs,
+            "node.announce_refresh_interval_secs",
+        )?;
+        nonzero(
+            self.node.peer_reconnect_interval_secs,
+            "node.peer_reconnect_interval_secs",
+        )?;
+        nonzero(
+            self.payments.final_cltv_expiry_delta as u64,
+            "payments.final_cltv_expiry_delta",
+        )?;
+        nonzero(
+            self.payments.max_swap_fee_msat,
+            "payments.max_swap_fee_msat",
+        )?;
+        nonzero(
+            self.payments.retry_timeout_secs,
+            "payments.retry_timeout_secs",
+        )?;
+        nonzero(self.rgb.fee_rate_sat_vb, "rgb.fee_rate_sat_vb")?;
+        nonzero(
+            self.rgb.min_channel_confirmations as u64,
+            "rgb.min_channel_confirmations",
+        )?;
+        nonzero(self.rgb.utxo_num as u64, "rgb.utxo_num")?;
+        nonzero(self.rgb.utxo_size_sat as u64, "rgb.utxo_size_sat")?;
+        Ok(())
+    }
+}
+
+fn apply<T: Copy>(target: &mut T, value: Option<T>) {
+    if let Some(value) = value {
+        *target = value;
+    }
+}
+
+fn nonzero(value: u64, key: &str) -> Result<(), AppError> {
+    if value == 0 {
+        return Err(invalid(format!("{key} must be greater than 0")));
+    }
+    Ok(())
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,0 +1,421 @@
+use super::*;
+
+fn cfg(content: &str) -> Result<Config, AppError> {
+    Config::from_toml(&TomlConfig::parse(content)?)
+}
+
+fn err_msg(res: Result<Config, AppError>) -> String {
+    match res {
+        Err(AppError::InvalidConfig(m)) => m,
+        other => panic!("expected InvalidConfig, got {other:?}"),
+    }
+}
+
+#[test]
+fn defaults_match_hardcoded_values() {
+    let c = Config::default();
+    assert_eq!(c.auth.password_min_length, 8);
+    assert_eq!(c.channels.dust_limit_msat, 546_000);
+    assert_eq!(c.channels.htlc_min_msat, 3_000_000);
+    assert_eq!(c.channels.open_max_sat, 16_777_215);
+    assert_eq!(c.channels.open_min_rgb_amount, 1);
+    assert_eq!(c.channels.open_min_sat, 5506);
+    assert_eq!(c.channels.open_rgb_min_sat(), 30_010);
+    assert_eq!(c.channels.their_to_self_delay, 2016);
+    assert_eq!(c.payments.final_cltv_expiry_delta, 14);
+    assert_eq!(c.payments.max_swap_fee_msat, 3_000_000);
+    assert_eq!(c.payments.retry_timeout_secs, 10);
+    assert_eq!(c.rgb.fee_rate_sat_vb, 7);
+    assert_eq!(c.rgb.min_channel_confirmations, 6);
+    assert_eq!(c.rgb.utxo_num, 4);
+    assert_eq!(c.rgb.utxo_size_sat, 32000);
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn timing_defaults_match_hardcoded_values() {
+    let c = Config::default();
+    assert_eq!(c.chain.fee_refresh_interval_secs, 60);
+    assert_eq!(c.node.announce_initial_delay_secs, 60);
+    assert_eq!(c.node.announce_refresh_interval_secs, 3600);
+    assert_eq!(c.node.peer_reconnect_interval_secs, 1);
+}
+
+#[test]
+fn empty_toml_keeps_defaults() {
+    assert_eq!(cfg("").unwrap(), Config::default());
+}
+
+#[test]
+fn partial_override_leaves_other_defaults() {
+    let c = cfg("[rgb]\nfee_rate_sat_vb = 12\n").unwrap();
+    assert_eq!(c.rgb.fee_rate_sat_vb, 12);
+    assert_eq!(c.rgb.utxo_size_sat, 32000);
+    assert_eq!(c.channels, Config::default().channels);
+}
+
+#[test]
+fn all_policy_sections_apply() {
+    let c = cfg(r#"
+[auth]
+password_min_length = 12
+
+[chain]
+fee_refresh_interval_secs = 120
+
+[channels]
+dust_limit_msat = 600000
+htlc_min_msat = 2000000
+open_max_sat = 1000000
+open_min_rgb_amount = 2
+open_min_sat = 10000
+their_to_self_delay = 1440
+
+[node]
+announce_initial_delay_secs = 30
+announce_refresh_interval_secs = 1800
+peer_reconnect_interval_secs = 2
+
+[payments]
+final_cltv_expiry_delta = 18
+max_swap_fee_msat = 5000000
+retry_timeout_secs = 30
+
+[rgb]
+fee_rate_sat_vb = 3
+min_channel_confirmations = 3
+utxo_num = 8
+utxo_size_sat = 64000
+"#)
+    .unwrap();
+    assert_eq!(c.auth.password_min_length, 12);
+    assert_eq!(c.chain.fee_refresh_interval_secs, 120);
+    assert_eq!(c.channels.dust_limit_msat, 600_000);
+    assert_eq!(c.channels.htlc_min_msat, 2_000_000);
+    assert_eq!(c.channels.open_max_sat, 1_000_000);
+    assert_eq!(c.channels.open_min_rgb_amount, 2);
+    assert_eq!(c.channels.open_min_sat, 10_000);
+    assert_eq!(c.channels.open_rgb_min_sat(), 20_010);
+    assert_eq!(c.channels.their_to_self_delay, 1440);
+    assert_eq!(c.node.announce_initial_delay_secs, 30);
+    assert_eq!(c.node.announce_refresh_interval_secs, 1800);
+    assert_eq!(c.node.peer_reconnect_interval_secs, 2);
+    assert_eq!(c.payments.final_cltv_expiry_delta, 18);
+    assert_eq!(c.payments.max_swap_fee_msat, 5_000_000);
+    assert_eq!(c.payments.retry_timeout_secs, 30);
+    assert_eq!(c.rgb.fee_rate_sat_vb, 3);
+    assert_eq!(c.rgb.min_channel_confirmations, 3);
+    assert_eq!(c.rgb.utxo_num, 8);
+    assert_eq!(c.rgb.utxo_size_sat, 64000);
+}
+
+#[test]
+fn startup_sections_parse() {
+    let t = TomlConfig::parse(
+        r#"
+[auth]
+disable_authentication = true
+
+[media]
+max_aggregated_media_size_per_channel_mb = 48
+max_media_files_per_channel = 84
+max_media_upload_size_mb = 10
+max_pending_consignments = 20
+
+[node]
+daemon_listening_port = 8888
+ldk_peer_listening_port = 9999
+network = "regtest"
+"#,
+    )
+    .unwrap();
+    let auth = t.auth.unwrap();
+    assert_eq!(auth.disable_authentication, Some(true));
+    let media = t.media.unwrap();
+    assert_eq!(media.max_aggregated_media_size_per_channel_mb, Some(48));
+    assert_eq!(media.max_media_files_per_channel, Some(84));
+    assert_eq!(media.max_media_upload_size_mb, Some(10));
+    assert_eq!(media.max_pending_consignments, Some(20));
+    let node = t.node.unwrap();
+    assert_eq!(node.daemon_listening_port, Some(8888));
+    assert_eq!(node.ldk_peer_listening_port, Some(9999));
+    assert_eq!(node.network.as_deref(), Some("regtest"));
+}
+
+#[test]
+fn unknown_section_rejected() {
+    let res = TomlConfig::parse("[bogus]\nkey = 1\n");
+    assert!(matches!(res, Err(AppError::InvalidConfig(ref m)) if m.contains("bogus")));
+}
+
+#[test]
+fn unknown_key_rejected() {
+    let res = TomlConfig::parse("[rgb]\nbogus_key = 1\n");
+    assert!(matches!(res, Err(AppError::InvalidConfig(ref m)) if m.contains("bogus_key")));
+}
+
+#[test]
+fn wrong_type_rejected() {
+    assert!(TomlConfig::parse("[rgb]\nfee_rate_sat_vb = \"high\"\n").is_err());
+}
+
+#[test]
+fn zero_fee_rate_rejected() {
+    let m = err_msg(cfg("[rgb]\nfee_rate_sat_vb = 0\n"));
+    assert!(m.contains("fee_rate_sat_vb"));
+}
+
+#[test]
+fn zero_utxo_size_rejected() {
+    let m = err_msg(cfg("[rgb]\nutxo_size_sat = 0\n"));
+    assert!(m.contains("utxo_size_sat"));
+}
+
+#[test]
+fn zero_utxo_num_rejected() {
+    let m = err_msg(cfg("[rgb]\nutxo_num = 0\n"));
+    assert!(m.contains("utxo_num"));
+}
+
+#[test]
+fn zero_min_channel_confirmations_rejected() {
+    let m = err_msg(cfg("[rgb]\nmin_channel_confirmations = 0\n"));
+    assert!(m.contains("min_channel_confirmations"));
+}
+
+#[test]
+fn zero_htlc_min_rejected() {
+    let m = err_msg(cfg("[channels]\nhtlc_min_msat = 0\n"));
+    assert!(m.contains("htlc_min_msat"));
+}
+
+#[test]
+fn zero_dust_limit_rejected() {
+    let m = err_msg(cfg("[channels]\ndust_limit_msat = 0\n"));
+    assert!(m.contains("dust_limit_msat"));
+}
+
+#[test]
+fn zero_open_min_rejected() {
+    let m = err_msg(cfg("[channels]\nopen_min_sat = 0\n"));
+    assert!(m.contains("open_min_sat"));
+}
+
+#[test]
+fn open_min_above_max_rejected() {
+    let m = err_msg(cfg(
+        "[channels]\nopen_min_sat = 20000\nopen_max_sat = 10000\n",
+    ));
+    assert!(m.contains("open_min_sat") && m.contains("open_max_sat"));
+}
+
+#[test]
+fn open_max_above_protocol_cap_rejected() {
+    let m = err_msg(cfg("[channels]\nopen_max_sat = 16777216\n"));
+    assert!(m.contains("open_max_sat"));
+}
+
+#[test]
+fn derived_rgb_min_above_max_rejected() {
+    // 20_000_000_000 msat derives a 200_000_010 sat RGB minimum, above the default open_max_sat
+    let m = err_msg(cfg("[channels]\nhtlc_min_msat = 20000000000\n"));
+    assert!(m.contains("open_max_sat"));
+}
+
+#[test]
+fn zero_open_min_rgb_amount_rejected() {
+    let m = err_msg(cfg("[channels]\nopen_min_rgb_amount = 0\n"));
+    assert!(m.contains("open_min_rgb_amount"));
+}
+
+#[test]
+fn zero_their_to_self_delay_rejected() {
+    let m = err_msg(cfg("[channels]\ntheir_to_self_delay = 0\n"));
+    assert!(m.contains("their_to_self_delay"));
+}
+
+#[test]
+fn their_to_self_delay_above_2016_rejected() {
+    let m = err_msg(cfg("[channels]\ntheir_to_self_delay = 2017\n"));
+    assert!(m.contains("their_to_self_delay"));
+}
+
+#[test]
+fn zero_final_cltv_rejected() {
+    let m = err_msg(cfg("[payments]\nfinal_cltv_expiry_delta = 0\n"));
+    assert!(m.contains("final_cltv_expiry_delta"));
+}
+
+#[test]
+fn zero_retry_timeout_rejected() {
+    let m = err_msg(cfg("[payments]\nretry_timeout_secs = 0\n"));
+    assert!(m.contains("retry_timeout_secs"));
+}
+
+#[test]
+fn zero_max_swap_fee_rejected() {
+    let m = err_msg(cfg("[payments]\nmax_swap_fee_msat = 0\n"));
+    assert!(m.contains("max_swap_fee_msat"));
+}
+
+#[test]
+fn zero_password_min_length_rejected() {
+    let m = err_msg(cfg("[auth]\npassword_min_length = 0\n"));
+    assert!(m.contains("password_min_length"));
+}
+
+#[test]
+fn zero_timing_values_rejected() {
+    for (section, key) in [
+        ("chain", "fee_refresh_interval_secs"),
+        ("node", "announce_refresh_interval_secs"),
+        ("node", "peer_reconnect_interval_secs"),
+    ] {
+        let m = err_msg(cfg(&format!("[{section}]\n{key} = 0\n")));
+        assert!(m.contains(key), "expected error naming {key}, got: {m}");
+    }
+}
+
+#[test]
+fn zero_announce_initial_delay_allowed() {
+    let c = cfg("[node]\nannounce_initial_delay_secs = 0\n").unwrap();
+    assert_eq!(c.node.announce_initial_delay_secs, 0);
+}
+
+#[test]
+fn load_missing_file_errors() {
+    assert!(matches!(
+        load_config_file(std::path::Path::new("/nonexistent/config.toml")),
+        Err(AppError::InvalidConfig(_))
+    ));
+}
+
+#[test]
+fn ldk_channel_defaults_match_upstream() {
+    let c = Config::default();
+    assert_eq!(c.channels.cltv_expiry_delta, 72);
+    assert_eq!(c.channels.forwarding_fee_base_msat, 1000);
+    assert_eq!(c.channels.forwarding_fee_proportional_millionths, 0);
+    assert_eq!(
+        c.channels.max_dust_htlc_exposure,
+        DustExposure::FeeRateMultiplier(10000)
+    );
+    assert_eq!(c.channels.max_inbound_htlc_value_in_flight_percent, 10);
+    assert_eq!(c.channels.max_minimum_depth, 144);
+    assert_eq!(c.channels.our_max_accepted_htlcs, 50);
+    assert_eq!(c.channels.our_to_self_delay, 144);
+    assert_eq!(
+        c.channels.channel_config(),
+        lightning::util::config::ChannelConfig::default()
+    );
+}
+
+#[test]
+fn ldk_channel_overrides_apply() {
+    let c = cfg(r#"
+[channels]
+cltv_expiry_delta = 80
+forwarding_fee_base_msat = 0
+forwarding_fee_proportional_millionths = 100
+max_dust_htlc_exposure_fixed_msat = 5000000
+max_inbound_htlc_value_in_flight_percent = 25
+max_minimum_depth = 6
+our_max_accepted_htlcs = 100
+our_to_self_delay = 288
+"#)
+    .unwrap();
+    assert_eq!(c.channels.cltv_expiry_delta, 80);
+    assert_eq!(c.channels.forwarding_fee_base_msat, 0);
+    assert_eq!(c.channels.forwarding_fee_proportional_millionths, 100);
+    assert_eq!(
+        c.channels.max_dust_htlc_exposure,
+        DustExposure::FixedLimitMsat(5_000_000)
+    );
+    assert_eq!(c.channels.max_inbound_htlc_value_in_flight_percent, 25);
+    assert_eq!(c.channels.max_minimum_depth, 6);
+    assert_eq!(c.channels.our_max_accepted_htlcs, 100);
+    assert_eq!(c.channels.our_to_self_delay, 288);
+    let ldk = c.channels.channel_config();
+    assert_eq!(ldk.cltv_expiry_delta, 80);
+    assert_eq!(ldk.forwarding_fee_base_msat, 0);
+    assert_eq!(ldk.forwarding_fee_proportional_millionths, 100);
+}
+
+#[test]
+fn dust_exposure_multiplier_key_applies() {
+    let c = cfg("[channels]\nmax_dust_htlc_exposure_multiplier = 20000\n").unwrap();
+    assert_eq!(
+        c.channels.max_dust_htlc_exposure,
+        DustExposure::FeeRateMultiplier(20000)
+    );
+}
+
+#[test]
+fn dust_exposure_keys_mutually_exclusive() {
+    let m = err_msg(cfg(
+        "[channels]\nmax_dust_htlc_exposure_multiplier = 20000\nmax_dust_htlc_exposure_fixed_msat = 5000000\n",
+    ));
+    assert!(m.contains("max_dust_htlc_exposure"));
+}
+
+#[test]
+fn zero_dust_exposure_rejected() {
+    for key in [
+        "max_dust_htlc_exposure_fixed_msat",
+        "max_dust_htlc_exposure_multiplier",
+    ] {
+        let m = err_msg(cfg(&format!("[channels]\n{key} = 0\n")));
+        assert!(m.contains(key), "expected error naming {key}, got: {m}");
+    }
+}
+
+#[test]
+fn cltv_expiry_delta_below_ldk_minimum_rejected() {
+    let m = err_msg(cfg("[channels]\ncltv_expiry_delta = 47\n"));
+    assert!(m.contains("cltv_expiry_delta"));
+    assert!(cfg("[channels]\ncltv_expiry_delta = 48\n").is_ok());
+}
+
+#[test]
+fn our_to_self_delay_out_of_bounds_rejected() {
+    let m = err_msg(cfg("[channels]\nour_to_self_delay = 143\n"));
+    assert!(m.contains("our_to_self_delay"));
+    let m = err_msg(cfg("[channels]\nour_to_self_delay = 2017\n"));
+    assert!(m.contains("our_to_self_delay"));
+    assert!(cfg("[channels]\nour_to_self_delay = 2016\n").is_ok());
+}
+
+#[test]
+fn max_inbound_htlc_percent_out_of_bounds_rejected() {
+    let m = err_msg(cfg(
+        "[channels]\nmax_inbound_htlc_value_in_flight_percent = 0\n",
+    ));
+    assert!(m.contains("max_inbound_htlc_value_in_flight_percent"));
+    let m = err_msg(cfg(
+        "[channels]\nmax_inbound_htlc_value_in_flight_percent = 101\n",
+    ));
+    assert!(m.contains("max_inbound_htlc_value_in_flight_percent"));
+    assert!(cfg("[channels]\nmax_inbound_htlc_value_in_flight_percent = 100\n").is_ok());
+}
+
+#[test]
+fn our_max_accepted_htlcs_out_of_bounds_rejected() {
+    let m = err_msg(cfg("[channels]\nour_max_accepted_htlcs = 0\n"));
+    assert!(m.contains("our_max_accepted_htlcs"));
+    let m = err_msg(cfg("[channels]\nour_max_accepted_htlcs = 484\n"));
+    assert!(m.contains("our_max_accepted_htlcs"));
+    assert!(cfg("[channels]\nour_max_accepted_htlcs = 483\n").is_ok());
+}
+
+#[test]
+fn zero_max_minimum_depth_rejected() {
+    let m = err_msg(cfg("[channels]\nmax_minimum_depth = 0\n"));
+    assert!(m.contains("max_minimum_depth"));
+}
+
+#[test]
+fn accept_forwards_to_priv_channels_defaults_off_and_applies() {
+    assert!(!Config::default().channels.accept_forwards_to_priv_channels);
+    let c = cfg("[channels]\naccept_forwards_to_priv_channels = true\n").unwrap();
+    assert!(c.channels.accept_forwards_to_priv_channels);
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -595,6 +595,9 @@ pub enum AppError {
     #[error("The provided authentication args are invalid")]
     InvalidAuthenticationArgs,
 
+    #[error("Invalid configuration: {0}")]
+    InvalidConfig(String),
+
     #[error("The revoked tokens file contains an invalid entry")]
     InvalidRevokedTokensFile,
 

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -116,7 +116,7 @@ use crate::rgb::{get_rgb_channel_info_optional, RgbLibWalletWrapper};
 use crate::rgb_file_transfer::{
     PeerChannelGate, RgbFileTransferHandler, REASSEMBLY_SWEEP_INTERVAL,
 };
-use crate::routes::{HTLCStatus, LdkChainSync, SwapStatus, UnlockRequest, DUST_LIMIT_MSAT};
+use crate::routes::{HTLCStatus, LdkChainSync, SwapStatus, UnlockRequest};
 use crate::swap::SwapData;
 use crate::utils::{
     check_port_is_available, connect_peer_if_necessary, do_connect_peer, get_current_timestamp,
@@ -823,12 +823,14 @@ async fn handle_ldk_events(
                 }]};
 
                 let unlocked_state_copy = unlocked_state.clone();
+                let fee_rate_sat_vb = static_state.config.rgb.fee_rate_sat_vb;
+                let min_channel_confirmations = static_state.config.rgb.min_channel_confirmations;
                 let res = tokio::task::spawn_blocking(move || {
                     let res = unlocked_state_copy.rgb_send_begin(
                         recipient_map,
                         true,
-                        FEE_RATE,
-                        MIN_CHANNEL_CONFIRMATIONS,
+                        fee_rate_sat_vb,
+                        min_channel_confirmations,
                         get_current_timestamp() + RGB_TRANSFER_CHAN_EXPIRATION_SECS,
                         false,
                     )?;
@@ -864,11 +866,12 @@ async fn handle_ldk_events(
             } else {
                 let unlocked_state_copy = unlocked_state.clone();
                 let btc_address = addr.to_address();
+                let fee_rate_sat_vb = static_state.config.rgb.fee_rate_sat_vb;
                 let res = tokio::task::spawn_blocking(move || {
                     unlocked_state_copy.rgb_send_btc_begin(
                         btc_address,
                         channel_value_satoshis,
-                        FEE_RATE,
+                        fee_rate_sat_vb,
                         false,
                     )
                 })
@@ -1810,7 +1813,9 @@ impl RgbOutputSpender {
                     .unwrap()
                     .unwrap();
                 txouts.push(TxOut {
-                    value: Amount::from_sat(DUST_LIMIT_MSAT / 1000),
+                    value: Amount::from_sat(
+                        self.static_state.config.channels.dust_limit_msat / 1000,
+                    ),
                     script_pubkey,
                 });
                 receive_data.recipient_id
@@ -1842,7 +1847,8 @@ impl RgbOutputSpender {
                 .map_err(|()| s!("cannot spend vanilla spendable outputs"));
         }
 
-        let feerate_sat_per_1000_weight = FEE_RATE as u32 * 250; // 1 sat/vB = 250 sat/kw
+        // 1 sat/vB = 250 sat/kw
+        let feerate_sat_per_1000_weight = self.static_state.config.rgb.fee_rate_sat_vb as u32 * 250;
         let (psbt, _expected_max_weight) =
             SpendableOutputDescriptor::create_spendable_outputs_psbt(
                 secp_ctx,
@@ -1998,6 +2004,7 @@ pub(crate) async fn start_ldk(
                 bitcoind_rpc_password.clone(),
                 handle.clone(),
                 Arc::clone(&logger),
+                static_state.config.chain.fee_refresh_interval_secs,
             )
             .await
             {
@@ -2055,6 +2062,7 @@ pub(crate) async fn start_ldk(
                     ln_indexer_protocol.clone(),
                     handle.clone(),
                     Arc::clone(&logger),
+                    static_state.config.chain.fee_refresh_interval_secs,
                 )
                 .map_err(|e| APIError::InvalidIndexer(e.to_string()))?,
             );
@@ -2167,13 +2175,25 @@ pub(crate) async fn start_ldk(
     ));
 
     // Initialize the ChannelManager
+    let channels_config = &static_state.config.channels;
     let mut user_config = UserConfig::default();
     user_config
         .channel_handshake_limits
         .force_announced_channel_preference = false;
+    user_config.channel_handshake_limits.their_to_self_delay = channels_config.their_to_self_delay;
+    user_config.channel_handshake_limits.max_minimum_depth = channels_config.max_minimum_depth;
     user_config
         .channel_handshake_config
         .negotiate_anchors_zero_fee_htlc_tx = true;
+    user_config.channel_handshake_config.our_to_self_delay = channels_config.our_to_self_delay;
+    user_config
+        .channel_handshake_config
+        .max_inbound_htlc_value_in_flight_percent_of_channel =
+        channels_config.max_inbound_htlc_value_in_flight_percent;
+    user_config.channel_handshake_config.our_max_accepted_htlcs =
+        channels_config.our_max_accepted_htlcs;
+    user_config.channel_config = channels_config.channel_config();
+    user_config.accept_forwards_to_priv_channels = channels_config.accept_forwards_to_priv_channels;
     user_config.manually_accept_inbound_channels = true;
     let manager_file = fs::File::open(ldk_data_dir.join("manager"));
     // `restarting_node` and `channel_manager_blockhash` are only consumed by the block-sync
@@ -2724,8 +2744,9 @@ pub(crate) async fn start_ldk(
     let connect_pm = Arc::clone(&peer_manager);
     let peer_data_path = ldk_data_dir.join(CHANNEL_PEER_DATA);
     let stop_connect = Arc::clone(&stop_processing);
+    let peer_reconnect_interval_secs = static_state.config.node.peer_reconnect_interval_secs;
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        let mut interval = tokio::time::interval(Duration::from_secs(peer_reconnect_interval_secs));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             interval.tick().await;
@@ -2803,12 +2824,15 @@ pub(crate) async fn start_ldk(
 
     let peer_man = Arc::clone(&peer_manager);
     let chan_man = Arc::clone(&channel_manager);
+    let announce_initial_delay_secs = static_state.config.node.announce_initial_delay_secs;
+    let announce_refresh_interval_secs = static_state.config.node.announce_refresh_interval_secs;
     tokio::spawn(async move {
         // First wait a minute until we have some peers and maybe have opened a channel.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_secs(announce_initial_delay_secs)).await;
         // Then, update our announcement once an hour to keep it fresh but avoid unnecessary churn
         // in the global gossip network.
-        let mut interval = tokio::time::interval(Duration::from_secs(3600));
+        let mut interval =
+            tokio::time::interval(Duration::from_secs(announce_refresh_interval_secs));
         loop {
             interval.tick().await;
             // Don't bother trying to announce if we don't have any public channls, though our

--- a/src/ldk_chain_backend/block_sync.rs
+++ b/src/ldk_chain_backend/block_sync.rs
@@ -123,6 +123,7 @@ impl BitcoindClient {
         rpc_password: String,
         handle: tokio::runtime::Handle,
         logger: Arc<FilesystemLogger>,
+        fee_refresh_interval_secs: u64,
     ) -> std::io::Result<Self> {
         let http_endpoint = HttpEndpoint::for_host(host.clone()).with_port(port);
         let rpc_credentials = general_purpose::STANDARD.encode(format!(
@@ -149,6 +150,7 @@ impl BitcoindClient {
             client.bitcoind_rpc_client.clone(),
             client.logger.clone(),
             handle,
+            fee_refresh_interval_secs,
         );
         Ok(client)
     }
@@ -158,6 +160,7 @@ impl BitcoindClient {
         rpc_client: Arc<RpcClient>,
         logger: Arc<FilesystemLogger>,
         handle: tokio::runtime::Handle,
+        fee_refresh_interval_secs: u64,
     ) {
         handle.spawn(async move {
             async fn get_estimate(
@@ -246,7 +249,7 @@ impl BitcoindClient {
                     mempoolmin_estimate,
                 );
 
-                tokio::time::sleep(Duration::from_secs(60)).await;
+                tokio::time::sleep(Duration::from_secs(fee_refresh_interval_secs)).await;
             }
         });
     }

--- a/src/ldk_chain_backend/transaction_sync.rs
+++ b/src/ldk_chain_backend/transaction_sync.rs
@@ -75,6 +75,7 @@ impl IndexerClient {
         protocol: RgbLibIndexerProtocol,
         handle: tokio::runtime::Handle,
         logger: Arc<FilesystemLogger>,
+        fee_refresh_interval_secs: u64,
     ) -> io::Result<Self> {
         let fees = Arc::new(default_fee_buckets());
         let backend = match protocol {
@@ -91,6 +92,7 @@ impl IndexerClient {
                     client.clone(),
                     logger.clone(),
                     handle.clone(),
+                    fee_refresh_interval_secs,
                 );
                 IndexerBackend::Electrum(client)
             }
@@ -105,6 +107,7 @@ impl IndexerClient {
                     client.clone(),
                     logger.clone(),
                     handle.clone(),
+                    fee_refresh_interval_secs,
                 );
                 IndexerBackend::Esplora(client)
             }
@@ -444,6 +447,7 @@ fn poll_electrum_fee_estimates(
     client: Arc<ElectrumClient>,
     logger: Arc<FilesystemLogger>,
     handle: tokio::runtime::Handle,
+    fee_refresh_interval_secs: u64,
 ) {
     handle.spawn(async move {
         loop {
@@ -484,7 +488,7 @@ fn poll_electrum_fee_estimates(
                 }
             }
 
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::time::sleep(Duration::from_secs(fee_refresh_interval_secs)).await;
         }
     });
 }
@@ -495,6 +499,7 @@ fn poll_esplora_fee_estimates(
     client: Arc<EsploraBlockingClient>,
     logger: Arc<FilesystemLogger>,
     handle: tokio::runtime::Handle,
+    fee_refresh_interval_secs: u64,
 ) {
     handle.spawn(async move {
         loop {
@@ -530,7 +535,7 @@ fn poll_esplora_fee_estimates(
                 Err(e) => log_warn!(logger, "Error polling esplora fee estimates: {}", e),
             }
 
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::time::sleep(Duration::from_secs(fee_refresh_interval_secs)).await;
         }
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ compile_error!(
 mod args;
 mod auth;
 mod backup;
+mod config;
 mod crypto;
 mod disk;
 mod error;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -20,7 +20,6 @@ use lightning::rgb_utils::{
 use lightning::routing::gossip::RoutingFees;
 use lightning::routing::router::{Path as LnPath, Route, RouteHint, RouteHintHop};
 use lightning::sign::EntropySource;
-use lightning::util::config::ChannelConfig;
 use lightning::{chain::channelmonitor::Balance, impl_writeable_tlv_based_enum};
 use lightning::{
     ln::channel_state::ChannelShutdownState, onion_message::messenger::MessageSendInstructions,
@@ -95,29 +94,19 @@ use crate::{
 use crate::{
     disk::{self, CHANNEL_PEER_DATA},
     error::APIError,
-    ldk::{PaymentInfo, UTXO_SIZE_SAT},
+    ldk::PaymentInfo,
     utils::{
         connect_peer_if_necessary, get_current_timestamp, no_cancel, parse_peer_info, AppState,
     },
 };
 use crate::{
     error::error_name,
-    ldk::{start_ldk, stop_ldk, LdkBackgroundServices, MIN_CHANNEL_CONFIRMATIONS},
+    ldk::{start_ldk, stop_ldk, LdkBackgroundServices},
 };
 
-const UTXO_NUM: u8 = 4;
-
 pub(crate) const HTLC_MIN_MSAT: u64 = 3000000;
-pub(crate) const MAX_SWAP_FEE_MSAT: u64 = HTLC_MIN_MSAT;
-
-const OPENRGBCHANNEL_MIN_SAT: u64 = HTLC_MIN_MSAT / 1000 * 10 + 10;
-const OPENCHANNEL_MIN_SAT: u64 = 5506;
-const OPENCHANNEL_MAX_SAT: u64 = 16777215;
-const OPENCHANNEL_MIN_RGB_AMT: u64 = 1;
 
 pub const DUST_LIMIT_MSAT: u64 = 546000;
-
-const INVOICE_MIN_MSAT: u64 = HTLC_MIN_MSAT;
 
 pub(crate) const DEFAULT_FINAL_CLTV_EXPIRY_DELTA: u32 = 14;
 
@@ -1739,7 +1728,10 @@ pub(crate) async fn change_password(
     no_cancel(async move {
         let _guard = state.check_locked().await?;
 
-        check_password_strength(payload.new_password.clone())?;
+        check_password_strength(
+            payload.new_password.clone(),
+            state.static_state.config.auth.password_min_length,
+        )?;
 
         let mnemonic =
             check_password_validity(&payload.old_password, &state.static_state.storage_dir_path)?;
@@ -1889,8 +1881,12 @@ pub(crate) async fn create_utxos(
 
         unlocked_state.rgb_create_utxos(
             payload.up_to,
-            payload.num.unwrap_or(UTXO_NUM),
-            payload.size.unwrap_or(UTXO_SIZE_SAT),
+            payload
+                .num
+                .unwrap_or(state.static_state.config.rgb.utxo_num),
+            payload
+                .size
+                .unwrap_or(state.static_state.config.rgb.utxo_size_sat),
             payload.fee_rate,
             payload.skip_sync,
         )?;
@@ -2291,7 +2287,10 @@ pub(crate) async fn init(
     no_cancel(async move {
         let _unlocked_state = state.check_locked().await?;
 
-        check_password_strength(payload.password.clone())?;
+        check_password_strength(
+            payload.password.clone(),
+            state.static_state.config.auth.password_min_length,
+        )?;
 
         let mnemonic_path = get_mnemonic_path(&state.static_state.storage_dir_path);
         check_already_initialized(&mnemonic_path)?;
@@ -2466,9 +2465,10 @@ pub(crate) async fn keysend(
         };
 
         let amt_msat = payload.amt_msat;
-        if amt_msat < HTLC_MIN_MSAT {
+        let htlc_min_msat = state.static_state.config.channels.htlc_min_msat;
+        if amt_msat < htlc_min_msat {
             return Err(APIError::InvalidAmount(format!(
-                "amt_msat cannot be less than {HTLC_MIN_MSAT}"
+                "amt_msat cannot be less than {htlc_min_msat}"
             )));
         }
 
@@ -2527,7 +2527,9 @@ pub(crate) async fn keysend(
             RecipientOnionFields::spontaneous_empty(),
             payment_id,
             route_params,
-            Retry::Timeout(Duration::from_secs(10)),
+            Retry::Timeout(Duration::from_secs(
+                state.static_state.config.payments.retry_timeout_secs,
+            )),
         ) {
             Ok(_payment_hash) => {
                 tracing::info!(
@@ -2982,9 +2984,10 @@ pub(crate) async fn ln_invoice(
             None
         };
 
-        if contract_id.is_some() && payload.amt_msat.unwrap_or(0) < INVOICE_MIN_MSAT {
+        let invoice_min_msat = state.static_state.config.channels.htlc_min_msat;
+        if contract_id.is_some() && payload.amt_msat.unwrap_or(0) < invoice_min_msat {
             return Err(APIError::InvalidAmount(format!(
-                "amt_msat cannot be less than {INVOICE_MIN_MSAT} when transferring an RGB asset"
+                "amt_msat cannot be less than {invoice_min_msat} when transferring an RGB asset"
             )));
         }
 
@@ -3149,16 +3152,18 @@ pub(crate) async fn maker_execute(
         let rgb_payment = swap_info
             .to_asset
             .map(|to_asset| (to_asset, swap_info.qty_to));
+        let htlc_min_msat = state.static_state.config.channels.htlc_min_msat;
         let first_leg = get_route(
+            &state.static_state.config,
             &unlocked_state.channel_manager,
             &unlocked_state.router,
             &state.static_state.ldk_data_dir,
             unlocked_state.channel_manager.get_our_node_id(),
             taker_pk,
             if swap_info.is_to_btc() {
-                Some(swap_info.qty_to + HTLC_MIN_MSAT)
+                Some(swap_info.qty_to + htlc_min_msat)
             } else {
-                Some(HTLC_MIN_MSAT)
+                Some(htlc_min_msat)
             },
             rgb_payment,
             vec![],
@@ -3168,15 +3173,16 @@ pub(crate) async fn maker_execute(
             .from_asset
             .map(|from_asset| (from_asset, swap_info.qty_from));
         let second_leg = get_route(
+            &state.static_state.config,
             &unlocked_state.channel_manager,
             &unlocked_state.router,
             &state.static_state.ldk_data_dir,
             taker_pk,
             unlocked_state.channel_manager.get_our_node_id(),
             if swap_info.is_to_btc() || swap_info.is_asset_asset() {
-                Some(HTLC_MIN_MSAT)
+                Some(htlc_min_msat)
             } else {
-                Some(swap_info.qty_from + HTLC_MIN_MSAT)
+                Some(swap_info.qty_from + htlc_min_msat)
             },
             rgb_payment,
             receive_hints,
@@ -3226,7 +3232,7 @@ pub(crate) async fn maker_execute(
             .map(|hop| hop.fee_msat)
             .sum::<u64>();
 
-        if total_fee >= MAX_SWAP_FEE_MSAT {
+        if total_fee >= state.static_state.config.payments.max_swap_fee_msat {
             return Err(APIError::FailedPayment(format!(
                 "Fee too high: {total_fee}"
             )));
@@ -3240,7 +3246,7 @@ pub(crate) async fn maker_execute(
             route_params: Some(RouteParameters {
                 payment_params: PaymentParameters::for_keysend(
                     unlocked_state.channel_manager.get_our_node_id(),
-                    DEFAULT_FINAL_CLTV_EXPIRY_DELTA,
+                    state.static_state.config.payments.final_cltv_expiry_delta,
                     false,
                 ),
                 // This value is not used anywhere, it's set by the router
@@ -3357,7 +3363,11 @@ pub(crate) async fn maker_init(
 
         let (payment_hash, payment_secret) = unlocked_state
             .channel_manager
-            .create_inbound_payment(Some(DUST_LIMIT_MSAT), payload.timeout_sec, None)
+            .create_inbound_payment(
+                Some(state.static_state.config.channels.dust_limit_msat),
+                payload.timeout_sec,
+                None,
+            )
             .unwrap();
         unlocked_state.add_maker_swap(payment_hash, swap_data);
 
@@ -3437,11 +3447,11 @@ pub(crate) async fn node_info(
         account_xpub_vanilla: unlocked_state.rgb_get_keys().account_xpub_vanilla,
         account_xpub_colored: unlocked_state.rgb_get_keys().account_xpub_colored,
         max_media_upload_size_mb: state.static_state.max_media_upload_size_mb,
-        rgb_htlc_min_msat: HTLC_MIN_MSAT,
-        rgb_channel_capacity_min_sat: OPENRGBCHANNEL_MIN_SAT,
-        channel_capacity_min_sat: OPENCHANNEL_MIN_SAT,
-        channel_capacity_max_sat: OPENCHANNEL_MAX_SAT,
-        channel_asset_min_amount: OPENCHANNEL_MIN_RGB_AMT,
+        rgb_htlc_min_msat: state.static_state.config.channels.htlc_min_msat,
+        rgb_channel_capacity_min_sat: state.static_state.config.channels.open_rgb_min_sat(),
+        channel_capacity_min_sat: state.static_state.config.channels.open_min_sat,
+        channel_capacity_max_sat: state.static_state.config.channels.open_max_sat,
+        channel_asset_min_amount: state.static_state.config.channels.open_min_rgb_amount,
         channel_asset_max_amount: u64::MAX,
         network_nodes,
         network_channels,
@@ -3466,10 +3476,12 @@ pub(crate) async fn open_channel(
             None
         };
 
+        let channels_config = &state.static_state.config.channels;
         let colored_info = match (payload.asset_id, payload.asset_amount) {
-            (Some(_), Some(amt)) if amt < OPENCHANNEL_MIN_RGB_AMT => {
+            (Some(_), Some(amt)) if amt < channels_config.open_min_rgb_amount => {
                 return Err(APIError::InvalidAmount(format!(
-                    "Channel RGB amount must be equal to or higher than {OPENCHANNEL_MIN_RGB_AMT}"
+                    "Channel RGB amount must be equal to or higher than {}",
+                    channels_config.open_min_rgb_amount
                 )));
             }
             (Some(asset), Some(amt)) => {
@@ -3483,18 +3495,21 @@ pub(crate) async fn open_channel(
             }
         };
 
-        if colored_info.is_some() && payload.capacity_sat < OPENRGBCHANNEL_MIN_SAT {
+        if colored_info.is_some() && payload.capacity_sat < channels_config.open_rgb_min_sat() {
             return Err(APIError::InvalidAmount(format!(
-                "RGB channel amount must be equal to or higher than {OPENRGBCHANNEL_MIN_SAT} sats"
+                "RGB channel amount must be equal to or higher than {} sats",
+                channels_config.open_rgb_min_sat()
             )));
-        } else if payload.capacity_sat < OPENCHANNEL_MIN_SAT {
+        } else if payload.capacity_sat < channels_config.open_min_sat {
             return Err(APIError::InvalidAmount(format!(
-                "Channel amount must be equal to or higher than {OPENCHANNEL_MIN_SAT} sats"
+                "Channel amount must be equal to or higher than {} sats",
+                channels_config.open_min_sat
             )));
         }
-        if payload.capacity_sat > OPENCHANNEL_MAX_SAT {
+        if payload.capacity_sat > channels_config.open_max_sat {
             return Err(APIError::InvalidAmount(format!(
-                "Channel amount must be equal to or less than {OPENCHANNEL_MAX_SAT} sats"
+                "Channel amount must be equal to or less than {} sats",
+                channels_config.open_max_sat
             )));
         }
 
@@ -3556,7 +3571,7 @@ pub(crate) async fn open_channel(
             )));
         }
 
-        let mut channel_config = ChannelConfig::default();
+        let mut channel_config = channels_config.channel_config();
         if let Some(fee_base_msat) = payload.fee_base_msat {
             channel_config.forwarding_fee_base_msat = fee_base_msat;
         }
@@ -3565,14 +3580,18 @@ pub(crate) async fn open_channel(
         }
         let config = UserConfig {
             channel_handshake_limits: ChannelHandshakeLimits {
-                // lnd's max to_self_delay is 2016, so we want to be compatible.
-                their_to_self_delay: 2016,
+                their_to_self_delay: channels_config.their_to_self_delay,
+                max_minimum_depth: channels_config.max_minimum_depth,
                 ..Default::default()
             },
             channel_handshake_config: ChannelHandshakeConfig {
                 announce_for_forwarding: payload.public,
-                our_htlc_minimum_msat: HTLC_MIN_MSAT,
-                minimum_depth: MIN_CHANNEL_CONFIRMATIONS as u32,
+                our_htlc_minimum_msat: channels_config.htlc_min_msat,
+                minimum_depth: state.static_state.config.rgb.min_channel_confirmations as u32,
+                our_to_self_delay: channels_config.our_to_self_delay,
+                max_inbound_htlc_value_in_flight_percent_of_channel: channels_config
+                    .max_inbound_htlc_value_in_flight_percent,
+                our_max_accepted_htlcs: channels_config.our_max_accepted_htlcs,
                 negotiate_anchors_zero_fee_htlc_tx: payload.with_anchors,
                 ..Default::default()
             },
@@ -4079,7 +4098,9 @@ pub(crate) async fn send_payment(
             )?;
 
             let params = OptionalOfferPaymentParams {
-                retry_strategy: Retry::Timeout(Duration::from_secs(10)),
+                retry_strategy: Retry::Timeout(Duration::from_secs(
+                    state.static_state.config.payments.retry_timeout_secs,
+                )),
                 ..Default::default()
             };
             let pay = unlocked_state.channel_manager
@@ -4120,19 +4141,20 @@ pub(crate) async fn send_payment(
                 invoice.amount_milli_satoshis().unwrap_or(0)
             };
 
+            let invoice_min_msat = state.static_state.config.channels.htlc_min_msat;
             let rgb_payment = match (invoice.rgb_contract_id(), invoice.rgb_amount()) {
                 (Some(rgb_contract_id), Some(rgb_amount)) => {
-                    if amt_msat < INVOICE_MIN_MSAT {
+                    if amt_msat < invoice_min_msat {
                         return Err(APIError::InvalidAmount(format!(
-                            "amt_msat in invoice sending an RGB asset cannot be less than {INVOICE_MIN_MSAT}"
+                            "amt_msat in invoice sending an RGB asset cannot be less than {invoice_min_msat}"
                         )));
                     }
                     Some((rgb_contract_id, rgb_amount))
                 },
                 (Some(rgb_contract_id), None) => {
-                    if amt_msat < INVOICE_MIN_MSAT {
+                    if amt_msat < invoice_min_msat {
                         return Err(APIError::InvalidAmount(format!(
-                            "amt_msat in invoice sending an RGB asset cannot be less than {INVOICE_MIN_MSAT}"
+                            "amt_msat in invoice sending an RGB asset cannot be less than {invoice_min_msat}"
                         )));
                     }
                     if let Some(asset_id) = payload.asset_id.as_ref() {
@@ -4189,7 +4211,9 @@ pub(crate) async fn send_payment(
                 payment_id,
                 Some(amt_msat),
                 RouteParametersConfig::default(),
-                Retry::Timeout(Duration::from_secs(10)),
+                Retry::Timeout(Duration::from_secs(
+                    state.static_state.config.payments.retry_timeout_secs,
+                )),
             ) {
                 Ok(_) => {
                     let payee_pubkey = invoice.recover_payee_pub_key();

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -109,6 +109,7 @@ impl Default for UserArgs {
             max_pending_consignments: 10,
             max_media_files_per_channel: 42,
             root_public_key: None,
+            config: Default::default(),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,7 +35,6 @@ use crate::crypto::{decrypt_mnemonic, encrypt_mnemonic};
 use crate::ldk::{ChannelIdsMap, Router};
 use crate::rgb::{get_rgb_channel_info_optional, RgbLibWalletWrapper};
 use crate::rgb_file_transfer::RgbFileTransferHandler;
-use crate::routes::{DEFAULT_FINAL_CLTV_EXPIRY_DELTA, HTLC_MIN_MSAT};
 use crate::{
     args::UserArgs,
     disk::FilesystemLogger,
@@ -54,7 +53,6 @@ pub(crate) const LOGS_DIR: &str = "logs";
 pub(crate) const ELECTRUM_URL_REGTEST: &str = "127.0.0.1:50001";
 #[cfg(all(test, feature = "electrum"))]
 pub(crate) const PROXY_ENDPOINT_LOCAL: &str = "rpc://127.0.0.1:3000/json-rpc";
-const PASSWORD_MIN_LENGTH: u8 = 8;
 
 pub(crate) struct AppState {
     pub(crate) static_state: Arc<StaticState>,
@@ -98,6 +96,7 @@ pub(crate) struct StaticState {
     pub(crate) max_aggregated_media_size_per_channel_mb: u16,
     pub(crate) max_pending_consignments: usize,
     pub(crate) max_media_files_per_channel: usize,
+    pub(crate) config: Arc<crate::config::Config>,
 }
 
 pub(crate) struct UnlockedAppState {
@@ -170,10 +169,10 @@ pub(crate) fn check_already_initialized(mnemonic_path: &Path) -> Result<(), APIE
     Ok(())
 }
 
-pub(crate) fn check_password_strength(password: String) -> Result<(), APIError> {
-    if password.len() < PASSWORD_MIN_LENGTH as usize {
+pub(crate) fn check_password_strength(password: String, min_length: u8) -> Result<(), APIError> {
+    if password.len() < min_length as usize {
         return Err(APIError::InvalidPassword(format!(
-            "must have at least {PASSWORD_MIN_LENGTH} chars"
+            "must have at least {min_length} chars"
         )));
     }
     Ok(())
@@ -373,6 +372,7 @@ pub(crate) async fn start_daemon(args: &UserArgs) -> Result<Arc<AppState>, AppEr
         max_aggregated_media_size_per_channel_mb: args.max_aggregated_media_size_per_channel_mb,
         max_pending_consignments: args.max_pending_consignments,
         max_media_files_per_channel: args.max_media_files_per_channel,
+        config: Arc::new(args.config.clone()),
     });
 
     let app_state = Arc::new(AppState {
@@ -422,6 +422,7 @@ pub(crate) fn get_max_local_rgb_amount<'r>(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn get_route(
+    config: &crate::config::Config,
     channel_manager: &crate::ldk::ChannelManager,
     router: &crate::ldk::Router,
     ldk_data_dir_path: &Path,
@@ -454,7 +455,7 @@ pub(crate) fn get_route(
             node_id: dest,
             route_hints: hints,
             features: None,
-            final_cltv_expiry_delta: DEFAULT_FINAL_CLTV_EXPIRY_DELTA,
+            final_cltv_expiry_delta: config.payments.final_cltv_expiry_delta,
         },
         expiry_time: None,
         max_total_cltv_expiry_delta: DEFAULT_MAX_TOTAL_CLTV_EXPIRY_DELTA,
@@ -468,7 +469,7 @@ pub(crate) fn get_route(
         &start,
         &RouteParameters {
             payment_params,
-            final_value_msat: final_value_msat.unwrap_or(HTLC_MIN_MSAT),
+            final_value_msat: final_value_msat.unwrap_or(config.channels.htlc_min_msat),
             max_total_routing_fee_msat: None,
             rgb_payment,
         },


### PR DESCRIPTION
Adds support for configuring the node via a TOML file, loaded from `<storage_directory_path>/config.toml` or the path given with `--config`. Values are resolved in order: built-in defaults, then the config file, then explicit CLI options. All current defaults are unchanged.

This moves the hardcoded policy constants (fee rate, UTXO size/count, channel confirmations, HTLC minimum, channel capacity bounds, swap fee cap, CLTV deltas, timers) and the LDK-inherited channel knobs (`cltv_expiry_delta`, `to_self_delay`, forwarding fees, dust exposure, in-flight limits, `accept_forwards_to_priv_channels`) into a `[section]`-based config, so nodes can be tuned without recompiling. The existing CLI args are also readable from the file, with the CLI taking precedence.

Every value is validated at startup (errors name the offending key) and unknown keys are rejected. All keys are documented with their defaults in `sample-config.toml`.