### PR TITLE
add deterministic test reproducing asset lockup on crash during colored channel open

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,31 +9,27 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Draft scope: only the funding-crash demonstration test runs, and it is
+# expected to fail (it reproduces the bug). The full suite returns before this
+# PR leaves draft.
 jobs:
-  test_and_coverage:
+  funding-crash-demo:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: llvm-tools-preview
           toolchain: stable
           rustflags: ""
-      - name: Install llvm-cov
-        env:
-          LLVM_COV_RELEASES: https://github.com/taiki-e/cargo-llvm-cov/releases
-        run: |
-          host=$(rustc -Vv | grep host | sed 's/host: //')
-          curl -fsSL $LLVM_COV_RELEASES/latest/download/cargo-llvm-cov-$host.tar.gz | tar xzf - -C "$HOME/.cargo/bin"
-      - name: Tests and coverage report
-        run: ./coverage.sh --ci
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v6
-        with:
-          fail_ci_if_error: true
-          file: coverage.lcov
-          flags: rust
-          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Build daemon binary (spawned as a subprocess by the test)
+        run: cargo build
+      - name: Start regtest services
+        run: ./regtest.sh start
+      - name: Run funding-crash demonstration test
+        run: SKIP_INIT=1 cargo test --bin rgb-lightning-node funding_crash -- --test-threads=1 --nocapture
+      - name: Stop regtest services
+        if: always()
+        run: ./regtest.sh stop

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -638,6 +638,25 @@ fn find_and_update_rgb_chan_amt(ldk_data_dir: &Path, payment_hash: &PaymentHash,
     }
 }
 
+// Funding checkpoint reached after the RGB stock is promoted (fascia consumed, allocations
+// swept into the batch transfer) but before the funding tx is handed to LDK.
+#[cfg(debug_assertions)]
+pub(crate) const FUNDING_CHECKPOINT_AFTER_COLOR: &str = "after-color-before-handoff";
+
+// Test-only crash injection: parks the process at a named funding checkpoint when
+// `RLN_FUNDING_KILL_AT` matches, so a test harness can SIGKILL it there. Debug builds only.
+#[cfg(debug_assertions)]
+fn funding_kill_checkpoint(name: &str) {
+    if std::env::var("RLN_FUNDING_KILL_AT").as_deref() == Ok(name) {
+        if let Ok(path) = std::env::var("RLN_FUNDING_KILL_READY_PATH") {
+            let _ = fs::write(path, name);
+        }
+        loop {
+            std::thread::park();
+        }
+    }
+}
+
 // Handle an rgb-lib error that happened while preparing a channel funding transaction in
 // FundingGenerationReady. Returns the value to propagate from the event handler: `Err(ReplayEvent)`
 // to retry the event (for transient network errors), or `Ok(())` after force-closing the channel
@@ -886,6 +905,8 @@ async fn handle_ldk_events(
                     Ok(unsigned_psbt) => (unsigned_psbt, None),
                 }
             };
+            #[cfg(debug_assertions)]
+            funding_kill_checkpoint(FUNDING_CHECKPOINT_AFTER_COLOR);
 
             let signed_psbt = unlocked_state.rgb_sign_psbt(unsigned_psbt).unwrap();
             let psbt = Psbt::from_str(&signed_psbt).unwrap();

--- a/src/test/funding_crash.rs
+++ b/src/test/funding_crash.rs
@@ -1,0 +1,200 @@
+use super::*;
+
+use crate::ldk::FUNDING_CHECKPOINT_AFTER_COLOR;
+
+const TEST_DIR_BASE: &str = "tmp/funding_crash/";
+
+/// Real daemon subprocess so the test can SIGKILL it at a funding checkpoint
+/// (in-process nodes cannot model an OS crash). A debug build is required: the
+/// crash checkpoint is compiled out under `--release`.
+struct DaemonProcess {
+    child: std::process::Child,
+    address: SocketAddr,
+}
+
+impl DaemonProcess {
+    fn kill(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl Drop for DaemonProcess {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
+
+fn daemon_binary() -> PathBuf {
+    let target_dir = std::env::var("CARGO_TARGET_DIR")
+        .unwrap_or_else(|_| format!("{}/target", env!("CARGO_MANIFEST_DIR")));
+    let bin = PathBuf::from(target_dir)
+        .join("debug")
+        .join("rgb-lightning-node");
+    assert!(
+        bin.exists(),
+        "daemon binary not found at {}; run `cargo build` first (a debug build is required)",
+        bin.display()
+    );
+    bin
+}
+
+async fn start_daemon_process(
+    node_test_dir: &str,
+    peer_port: u16,
+    envs: &[(&str, &str)],
+) -> DaemonProcess {
+    let daemon_port = {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.local_addr().unwrap().port()
+    };
+    std::fs::create_dir_all(node_test_dir).unwrap();
+    let log = std::fs::File::create(format!("{node_test_dir}/daemon.log")).unwrap();
+    let mut cmd = std::process::Command::new(daemon_binary());
+    cmd.arg(node_test_dir)
+        .arg("--daemon-listening-port")
+        .arg(daemon_port.to_string())
+        .arg("--ldk-peer-listening-port")
+        .arg(peer_port.to_string())
+        .arg("--network")
+        .arg("regtest")
+        .arg("--disable-authentication")
+        .stdout(std::process::Stdio::from(log.try_clone().unwrap()))
+        .stderr(std::process::Stdio::from(log));
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    let child = cmd.spawn().expect("spawn daemon");
+    let address: SocketAddr = format!("127.0.0.1:{daemon_port}").parse().unwrap();
+
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        if std::net::TcpStream::connect_timeout(&address, std::time::Duration::from_millis(200))
+            .is_ok()
+        {
+            break;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 30.0 {
+            panic!("daemon did not come up on {address}");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+    DaemonProcess { child, address }
+}
+
+/// Bind a free TCP port and release it, returning the number. Used for the
+/// restarted node so it never races the just-killed process for its port.
+fn free_peer_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Wait for the daemon to signal the checkpoint by writing the ready file.
+/// Fails fast (rather than after the full timeout) if the daemon exits before
+/// the checkpoint, so an unrelated crash reports its real cause.
+async fn wait_for_checkpoint(daemon: &mut DaemonProcess, ready_path: &str, timeout_secs: f32) {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        if Path::new(ready_path).exists() {
+            return;
+        }
+        if let Some(status) = daemon.child.try_wait().expect("poll daemon status") {
+            panic!("daemon exited ({status}) before reaching the funding checkpoint");
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > timeout_secs {
+            panic!("timeout waiting for the funding checkpoint at {ready_path}");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+}
+
+/// A sender killed after coloring the funding (allocations moved into a batch
+/// transfer and the fascia consumed into the stock) but before the funding
+/// transaction is handed to LDK must come back with its asset spendability
+/// intact: the channel never existed, so nothing may stay locked. On current
+/// code the entire asset balance (channel amount and change) remains locked
+/// to the dead open, with no recovery at startup and `/failtransfers`
+/// refusing to fail the batch because its fascia is already consumed.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sender_crash_after_color_leaves_assets_locked() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}sender_node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}sender_node2");
+    let ready_path = format!("{TEST_DIR_BASE}sender_kill_ready");
+    let _ = std::fs::remove_dir_all(&test_dir_node1);
+    let _ = std::fs::remove_file(&ready_path);
+
+    let mut node1 = start_daemon_process(
+        &test_dir_node1,
+        NODE1_PEER_PORT,
+        &[
+            ("RLN_FUNDING_KILL_AT", FUNDING_CHECKPOINT_AFTER_COLOR),
+            ("RLN_FUNDING_KILL_READY_PATH", &ready_path),
+        ],
+    )
+    .await;
+    let password = "funding_crash_sender";
+    init(node1.address, password, None).await;
+    unlock(node1.address, password).await;
+
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1.address, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset = issue_asset_nia(node1.address).await;
+    let initial_spendable = asset_balance_spendable(node1.address, &asset.asset_id).await;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    // Fire-only POST: the funding is deliberately halted at the checkpoint,
+    // so we must not wait for the channel to fund.
+    open_channel_raw(
+        node1.address,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        Some(600),
+        Some(&asset.asset_id),
+        None,
+        None,
+        None,
+        None,
+        true,
+        true,
+    )
+    .await
+    .expect("open channel request");
+
+    // The child parks after rgb_send_begin + rgb_consume_fascia, before the
+    // funding tx is signed or handed to LDK: allocations are locked and the
+    // stock already holds the transition for a channel that will never exist.
+    wait_for_checkpoint(&mut node1, &ready_path, 60.0).await;
+    assert_eq!(
+        std::fs::read_to_string(&ready_path).expect("read ready file"),
+        FUNDING_CHECKPOINT_AFTER_COLOR,
+        "the crash must fire at the post-coloring checkpoint, not another write"
+    );
+    node1.kill();
+
+    // Restart over the same data dir with a fresh peer port (the dead channel
+    // is not resumable, so node1b needs no specific port and must not race the
+    // just-killed process for it). No crash injection this time.
+    let node1b = start_daemon_process(&test_dir_node1, free_peer_port(), &[]).await;
+    unlock(node1b.address, password).await;
+
+    let spendable = asset_balance_spendable(node1b.address, &asset.asset_id).await;
+    assert_eq!(
+        spendable, initial_spendable,
+        "restart after a crash mid-open must release the allocations colored \
+         for the dead channel: they stay locked with no channel and no \
+         automatic recovery"
+    );
+
+    shutdown(&[node2_addr]).await;
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2375,6 +2375,8 @@ mod drop_funding_signed;
 #[cfg(all(feature = "transaction-sync", feature = "electrum"))]
 mod electrum_opret_confirm;
 mod fail_transfers;
+#[cfg(debug_assertions)]
+mod funding_crash;
 mod getchannelid;
 mod htlc_amount_checks;
 mod inflate;


### PR DESCRIPTION
When opening an RGB channel, the funder's FundingGenerationReady handler colors the funding transaction: it calls rgb_send_begin (sweeping the channel amount and the change into a batch transfer), consumes the resulting fascia into the stock (rgb_consume_fascia), and creates the consignments, all before the funding transaction is signed and handed to LDK (funding_transaction_generated).

If the process dies in that window, a restart is left in an inconsistent state:

- LDK has no channel (funding was never handed off), so nothing resumes it.
- The RGB wallet has already promoted the transition into the stock and moved every allocation into a batch transfer tied to a funding transaction that will never be broadcast.
- There is no startup reconciliation to detect and undo this.
- /failtransfers cannot release it either: the batch's fascia is already consumed, so the transfer is not in a failable state.

Net effect: after the crash the funder's entire spendable balance for that asset is stuck at 0, unrecoverable through any existing API. It needs only a local crash at an unlucky moment during any colored channel open.

How the test reproduces it

A debug-only crash checkpoint (funding_kill_checkpoint, #[cfg(debug_assertions)], gated behind the RLN_FUNDING_KILL_AT env var) is placed at exactly that point, after coloring, before the LDK handoff. The test:

1. Starts the funder (node1) as a real daemon subprocess with the checkpoint armed, plus a normal counterparty (node2). A subprocess is required because in-process test nodes cannot model an OS crash.
2. Funds both, issues an asset on node1, records node1's spendable balance.
3. Fires an openchannel for part of the asset (funding is deliberately halted).
4. node1 reaches the checkpoint (coloring done, stock promoted, not yet handed off), signals via a ready file, and parks.
5. SIGKILLs node1, the exact on-disk state a crash leaves at that instant.
6. Restarts node1 over the same data dir and asserts its spendable balance is fully restored.

On master, step 6 fails: spendable is 0, the whole balance stranded.