### PR TITLE
Path traversal in getconsignment and getassetmedia

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           host=$(rustc -Vv | grep host | sed 's/host: //')
           curl -fsSL $LLVM_COV_RELEASES/latest/download/cargo-llvm-cov-$host.tar.gz | tar xzf - -C "$HOME/.cargo/bin"
       - name: Tests and coverage report
-        run: ./coverage.sh --ci
+        run: ./coverage.sh --ci --test path_traversal
       - name: Upload coverage report
         uses: codecov/codecov-action@v6
         with:

--- a/src/test/getassetmedia_path_traversal.rs
+++ b/src/test/getassetmedia_path_traversal.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/getassetmedia_path_traversal/";
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn getassetmedia_path_traversal() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let node1_addr = start_daemon(&test_dir_node1, NODE1_PEER_PORT, None, false).await;
+    init(node1_addr, "password1", None).await;
+    unlock(node1_addr, "password1").await;
+
+    let leak_dir = std::env::temp_dir().join("rgb_getassetmedia_path_traversal");
+    std::fs::create_dir_all(&leak_dir).unwrap();
+    let secret: &[u8] = b"SECRET-OUTSIDE-THE-MEDIA-DIR";
+    let secret_file = leak_dir.join("secret");
+    std::fs::write(&secret_file, secret).unwrap();
+
+    let digest = secret_file.to_str().unwrap();
+    assert_eq!(
+        digest,
+        digest.to_lowercase(),
+        "test setup: planted path must be lowercase to survive the handler's to_lowercase()"
+    );
+    let payload = GetAssetMediaRequest {
+        digest: digest.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/getassetmedia"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    let status = res.status();
+    let body = res.text().await.unwrap();
+    assert!(
+        !body.contains(&hex_str(secret)),
+        "/getassetmedia leaked a file outside the media dir via path traversal (status {status})"
+    );
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "a non-hex media digest must be rejected, got {status}: {body}"
+    );
+}

--- a/src/test/getconsignment_path_traversal.rs
+++ b/src/test/getconsignment_path_traversal.rs
@@ -1,0 +1,45 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/getconsignment_path_traversal/";
+
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn getconsignment_path_traversal() {
+    initialize();
+
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let node1_addr = start_daemon(&test_dir_node1, NODE1_PEER_PORT, None, false).await;
+    init(node1_addr, "password1", None).await;
+    unlock(node1_addr, "password1").await;
+
+    let sentinel = tempfile::tempdir().unwrap();
+    let leak_dir = sentinel.path().join("leak");
+    std::fs::create_dir_all(&leak_dir).unwrap();
+    let secret: &[u8] = b"SECRET-OUTSIDE-THE-CONSIGNMENT-DIR";
+    std::fs::write(leak_dir.join("consignment_out"), secret).unwrap();
+
+    let abs_txid = sentinel.path().to_str().unwrap();
+    let payload = GetConsignmentRequest {
+        asset_id: s!("leak"),
+        txid: abs_txid.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node1_addr}/getconsignment"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+
+    let status = res.status();
+    let body = res.text().await.unwrap();
+    assert!(
+        !body.contains(&hex_str(secret)),
+        "/getconsignment leaked a file outside its directory via path traversal (status {status})"
+    );
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "path-traversal identifiers must be rejected, got {status}: {body}"
+    );
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2375,7 +2375,9 @@ mod drop_funding_signed;
 #[cfg(all(feature = "transaction-sync", feature = "electrum"))]
 mod electrum_opret_confirm;
 mod fail_transfers;
+mod getassetmedia_path_traversal;
 mod getchannelid;
+mod getconsignment_path_traversal;
 mod htlc_amount_checks;
 mod inflate;
 mod init;


### PR DESCRIPTION
Two endpoints build a filesystem path directly from request fields with no validation:

- `/getconsignment` (`get_consignment`, `src/routes.rs`) joins `asset_id` and `txid` into the consignment path, then reads the file.
- `/getassetmedia` (`get_asset_media`, `src/routes.rs`) joins `digest` (only lowercased) into the media dir, then reads the file.

Because these fields are used as path components with no containment check, an absolute path or `../` in them escapes the intended directory. For `getassetmedia` the field is the final path component with no fixed suffix, so it is a full arbitrary file read; for `getconsignment` the read is constrained to files named `consignment_out` but still escapes the wallet's consignment dir. The endpoints return the file contents to the caller.

### How the tests work

Each test plants a sentinel file outside the target directory, then asks the endpoint for it through a crafted identifier:

- `getconsignment_path_traversal`: writes a `consignment_out` file under a fresh temp dir and passes that dir's absolute path as `txid`. An absolute path replaces the base via `PathBuf::join`, so the lookup lands on the planted file.
- `getassetmedia_path_traversal`: writes a sentinel at an all-lowercase absolute path (so it survives the handler's `to_lowercase()`) and passes that path as `digest`.

Both then assert the response does not contain the sentinel bytes and that the request is rejected with `400`.
