### PR TITLE
Peer media persisted before funding validation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           host=$(rustc -Vv | grep host | sed 's/host: //')
           curl -fsSL $LLVM_COV_RELEASES/latest/download/cargo-llvm-cov-$host.tar.gz | tar xzf - -C "$HOME/.cargo/bin"
       - name: Tests and coverage report
-        run: ./coverage.sh --ci
+        run: ./coverage.sh --ci --test funding_persist_before_validate
       - name: Upload coverage report
         uses: codecov/codecov-action@v6
         with:

--- a/src/test/funding_persist_before_validate.rs
+++ b/src/test/funding_persist_before_validate.rs
@@ -1,0 +1,82 @@
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/funding_persist_before_validate/";
+
+/// A counterparty that puts more `push_asset_amount` on the wire than the channel asset amount
+/// makes the acceptor reject the funding. The acceptor must not have persisted the peer's media
+/// before that rejection: validation has to happen before anything is written to the wallet dirs.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn funding_persist_before_validate() {
+    initialize();
+
+    let file_path = "README.md";
+    let test_dir_node1 = format!("{TEST_DIR_BASE}node1");
+    let test_dir_node2 = format!("{TEST_DIR_BASE}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let node1_pubkey = node_info(node1_addr).await.pubkey;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    let asset = issue_asset_cfa(node1_addr, Some(file_path)).await;
+    let digest = asset.media.unwrap().digest;
+
+    // baseline: node2 must not have the media before the channel attempt
+    let pre = reqwest::Client::new()
+        .post(format!("http://{node2_addr}/getassetmedia"))
+        .json(&GetAssetMediaRequest {
+            digest: digest.clone(),
+        })
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        pre.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "node2 unexpectedly already had the media before the channel attempt"
+    );
+
+    let _force_guard = NodeOverrideGuard::set(&FORCE_PUSH_ASSET_AMOUNT_ON_NODE, &node1_pubkey);
+
+    open_channel_raw(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(100_000),
+        None,
+        Some(100),
+        Some(&asset.asset_id),
+        Some(0),
+        None,
+        None,
+        None,
+        true,
+        true,
+    )
+    .await
+    .unwrap();
+
+    // node2 rejects the funding, which discards node1's pending channel
+    wait_for_no_channels(node1_addr).await;
+    assert!(list_channels(node2_addr).await.is_empty());
+
+    let payload = GetAssetMediaRequest {
+        digest: digest.clone(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node2_addr}/getassetmedia"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "acceptor persisted peer media before validating the funding (persist-before-validate)"
+    );
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2164,6 +2164,20 @@ async fn wait_for_usable_channels(node_address: SocketAddr, expected_num_usable_
     }
 }
 
+async fn wait_for_no_channels(node_address: SocketAddr) {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        let num_channels = list_channels(node_address).await.len();
+        if num_channels == 0 {
+            break;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 30.0 {
+            panic!("channels are not becoming empty ({num_channels} remaining)");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
 async fn wait_for_ln_payment(
     node_address: SocketAddr,
     payment_hash: &str,
@@ -2375,6 +2389,7 @@ mod drop_funding_signed;
 #[cfg(all(feature = "transaction-sync", feature = "electrum"))]
 mod electrum_opret_confirm;
 mod fail_transfers;
+mod funding_persist_before_validate;
 mod getchannelid;
 mod htlc_amount_checks;
 mod inflate;


### PR DESCRIPTION
In `handle_funding` (`lightning/src/rgb_utils/mod.rs`) the acceptor renames the peer's media files into its permanent media dir before it validates the funding (the RGB assignment count and the `push_asset_amount` bound). If that validation then fails, the channel is correctly rejected, but the peer-controlled media is already committed to the wallet's media dir with no rollback, leaving orphaned files behind.

### How the test works

`funding_persist_before_validate` drives a real funding between two nodes:

- node1 issues a CFA asset with a media file and opens a colored channel to a fresh node2.
- node1 puts more `push_asset_amount` on the wire than the channel asset amount (via the existing test override), which the acceptor must reject.

The test first confirms node2 does not have the media (baseline `getassetmedia` -> `400`), so any later presence is caused by this funding. After node2 rejects the funding (observed via node1's pending channel being discarded), it asks node2 for the media again and asserts `400`.
