### PR TITLE
test: failing regression tests for #160 — RGB effects before peer msg…

### DIFF
--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -180,50 +180,27 @@ pub(crate) fn node_override_matches(
 
 // Test-only: the node with this pubkey puts an extra witness recipient of its own in front of the
 // channel output when it builds a colored funding transaction, so the channel output lands at vout
-// 2 instead of vout 1. Models a funding initiator that does not follow the one-recipient
-// convention: the funding transaction is built entirely by the initiator and LDK carries the
-// resulting index in `funding_created.funding_output_index`, so a peer is free to do this.
+// 2 instead of the vout 1 the acceptor assumes. A peer is free to do this: the funding transaction
+// is built entirely by the initiator and LDK carries the resulting index in
+// `funding_created.funding_output_index`.
 #[cfg(test)]
 pub(crate) static DECOY_FUNDING_OUTPUT_ON_NODE: Mutex<Option<PublicKey>> = Mutex::new(None);
-
-// Test-only: the token RGB amount that goes to whichever of the two outputs is not meant to hold
-// the channel's assets when DECOY_FUNDING_OUTPUT_ON_NODE applies (rgb-lib rejects an assignment of
-// zero).
-#[cfg(test)]
-pub(crate) const DECOY_CHANNEL_ASSET_AMT: u64 = 1;
-
-// Test-only: which of the two outputs the channel's nominal RGB amount goes to when
-// DECOY_FUNDING_OUTPUT_ON_NODE applies. False (the default) leaves the assets on the channel
-// output and only moves its index; true keeps them on the initiator's own decoy output, so that
-// both peers agree on an RGB balance the funding output does not hold.
-#[cfg(test)]
-pub(crate) static DECOY_KEEPS_CHANNEL_ASSETS: AtomicBool = AtomicBool::new(false);
 
 // Test-only: satoshis paid to the decoy output built for DECOY_FUNDING_OUTPUT_ON_NODE
 #[cfg(test)]
 pub(crate) const DECOY_OUTPUT_SAT: u64 = 5_000;
 
-// Test-only: makes the decoy output built for DECOY_FUNDING_OUTPUT_ON_NODE pay the channel's own
-// script instead of a fresh wallet address, so the funding transaction would carry that script
-// twice — with a different value, which is the only shape in which the initiator's
-// `position(|o| o.script_pubkey == script_buf)` search and LDK's own script-and-value search can
-// disagree. Only has an effect together with DECOY_FUNDING_OUTPUT_ON_NODE.
-#[cfg(test)]
-pub(crate) static DECOY_REUSES_CHANNEL_SCRIPT: AtomicBool = AtomicBool::new(false);
-
 // Test-only: makes the decoy output built for DECOY_FUNDING_OUTPUT_ON_NODE receive an inflation
-// right instead of a fungible amount, so that the assignment the acceptor finds at its hard-coded
-// funding vout is one `handle_funding` has no arm for. Only meaningful for an IFA asset (rgb-lib
-// rejects an inflation-right recipient for any other schema) and only together with
-// DECOY_FUNDING_OUTPUT_ON_NODE.
+// right instead of a fungible amount, so the assignment the acceptor finds at its hard-coded
+// funding vout is one `handle_funding` has no arm for. Only meaningful for an IFA asset and only
+// together with DECOY_FUNDING_OUTPUT_ON_NODE.
 #[cfg(test)]
 pub(crate) static DECOY_INFLATION_ASSIGNMENT: AtomicBool = AtomicBool::new(false);
 
 // Test-only: the node with this pubkey sends the file named by SUBSTITUTE_CONSIGNMENT_PATH to its
 // counterparty in place of the consignment for the funding transaction it just built. Models a
-// peer that puts arbitrary bytes on the p2p link: the acceptor stores whatever arrives as
-// `consignment_{funding_txid}` and feeds it to `_accept_transfer` without ever having asked for
-// that particular consignment.
+// peer that puts arbitrary bytes on the p2p link: the acceptor stores whatever arrives and feeds
+// it to `_accept_transfer` without ever having asked for that particular consignment.
 #[cfg(test)]
 pub(crate) static SUBSTITUTE_CONSIGNMENT_ON_NODE: Mutex<Option<PublicKey>> = Mutex::new(None);
 
@@ -864,53 +841,48 @@ async fn handle_ldk_events(
                 let recipient_id =
                     recipient_id_from_script_buf(script_buf.clone(), static_state.network);
 
+                let recipient_map = map! {
+                    asset_id.clone() => vec![Recipient {
+                        recipient_id: recipient_id.clone(),
+                        witness_data: Some(WitnessData {
+                            amount_sat: channel_value_satoshis,
+                            blinding: Some(STATIC_BLINDING),
+                        }),
+                        assignment,
+                        transport_endpoints: vec![]
+                }]};
+                // Test-only: prepend a decoy recipient of the initiator's own, so the channel
+                // output no longer lands at the vout the acceptor assumes
                 #[cfg(test)]
-                let decoy_funding_output = DECOY_FUNDING_OUTPUT_ON_NODE
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .is_some_and(|id| *id == unlocked_state.channel_manager.get_our_node_id());
-                #[cfg(test)]
-                let (decoy_recipient, assignment) = if decoy_funding_output {
-                    let Assignment::Fungible(amount) = assignment else {
-                        panic!("TEST: the decoy funding output needs a fungible assignment")
-                    };
-                    let decoy_script = if DECOY_REUSES_CHANNEL_SCRIPT.load(Ordering::SeqCst) {
-                        script_buf.clone()
-                    } else {
-                        let unlocked_state_copy = unlocked_state.clone();
-                        let decoy_address = tokio::task::spawn_blocking(move || {
-                            unlocked_state_copy.rgb_get_address()
-                        })
-                        .await
-                        .unwrap()
-                        .unwrap();
-                        rgb_lib::bitcoin::Address::from_str(&decoy_address)
+                let recipient_map = if node_override_matches(
+                    &DECOY_FUNDING_OUTPUT_ON_NODE,
+                    unlocked_state.channel_manager.get_our_node_id(),
+                ) {
+                    let unlocked_state_copy = unlocked_state.clone();
+                    let decoy_address =
+                        tokio::task::spawn_blocking(move || unlocked_state_copy.rgb_get_address())
+                            .await
                             .unwrap()
-                            .assume_checked()
-                            .script_pubkey()
-                    };
-                    let (decoy_amount, channel_amount) =
-                        if DECOY_KEEPS_CHANNEL_ASSETS.load(Ordering::SeqCst) {
-                            (amount, DECOY_CHANNEL_ASSET_AMT)
-                        } else {
-                            (DECOY_CHANNEL_ASSET_AMT, amount)
-                        };
+                            .unwrap();
+                    // rgb-lib rejects an assignment of zero, so the decoy carries a token 1
                     let decoy_assignment = if DECOY_INFLATION_ASSIGNMENT.load(Ordering::SeqCst) {
-                        Assignment::InflationRight(decoy_amount)
+                        Assignment::InflationRight(1)
                     } else {
-                        Assignment::Fungible(decoy_amount)
+                        Assignment::Fungible(1)
                     };
                     tracing::info!(
-                        "TEST: putting {decoy_assignment:?} of asset {asset_id} on a decoy output \
-                         to script {} ahead of the channel output, leaving {channel_amount} on \
-                         the channel output",
-                        decoy_script.to_hex_string()
+                        "TEST: putting {decoy_assignment:?} of asset {asset_id} on a decoy \
+                         output ahead of the channel output"
                     );
-                    (
-                        Some(Recipient {
+                    let mut recipient_map = recipient_map;
+                    recipient_map.get_mut(&asset_id).unwrap().insert(
+                        0,
+                        Recipient {
                             recipient_id: recipient_id_from_script_buf(
-                                decoy_script,
+                                rgb_lib::bitcoin::Address::from_str(&decoy_address)
+                                    .unwrap()
+                                    .assume_checked()
+                                    .script_pubkey(),
                                 static_state.network,
                             ),
                             witness_data: Some(WitnessData {
@@ -919,34 +891,12 @@ async fn handle_ldk_events(
                             }),
                             assignment: decoy_assignment,
                             transport_endpoints: vec![],
-                        }),
-                        Assignment::Fungible(channel_amount),
-                    )
+                        },
+                    );
+                    recipient_map
                 } else {
-                    (None, assignment)
+                    recipient_map
                 };
-
-                let recipients: Vec<Recipient> = vec![Recipient {
-                    recipient_id: recipient_id.clone(),
-                    witness_data: Some(WitnessData {
-                        amount_sat: channel_value_satoshis,
-                        blinding: Some(STATIC_BLINDING),
-                    }),
-                    assignment,
-                    transport_endpoints: vec![],
-                }];
-                // the decoy is prepended, so the channel output no longer lands where an
-                // unhooked node would put it
-                #[cfg(test)]
-                let recipients = match decoy_recipient {
-                    Some(decoy) => {
-                        let mut with_decoy = vec![decoy];
-                        with_decoy.extend(recipients);
-                        with_decoy
-                    }
-                    None => recipients,
-                };
-                let recipient_map = map! { asset_id.clone() => recipients };
 
                 let unlocked_state_copy = unlocked_state.clone();
                 let res = tokio::task::spawn_blocking(move || {
@@ -1061,28 +1011,23 @@ async fn handle_ldk_events(
                 let consignment_path =
                     unlocked_state.rgb_get_send_consignment_path(&asset_id, &funding_txid_str);
                 #[cfg(test)]
-                let consignment_path = {
-                    let substitute = SUBSTITUTE_CONSIGNMENT_ON_NODE
+                let consignment_path = if node_override_matches(
+                    &SUBSTITUTE_CONSIGNMENT_ON_NODE,
+                    unlocked_state.channel_manager.get_our_node_id(),
+                ) {
+                    let path = SUBSTITUTE_CONSIGNMENT_PATH
                         .lock()
                         .unwrap()
-                        .as_ref()
-                        .is_some_and(|id| *id == unlocked_state.channel_manager.get_our_node_id())
-                        .then(|| {
-                            SUBSTITUTE_CONSIGNMENT_PATH.lock().unwrap().clone().expect(
-                                "TEST: SUBSTITUTE_CONSIGNMENT_ON_NODE needs a substitute path",
-                            )
-                        });
-                    match substitute {
-                        Some(path) => {
-                            tracing::info!(
-                                "TEST: sending {} to the counterparty instead of the consignment \
-                                 for funding {funding_txid_str}",
-                                path.display()
-                            );
-                            path
-                        }
-                        None => consignment_path,
-                    }
+                        .clone()
+                        .expect("TEST: SUBSTITUTE_CONSIGNMENT_ON_NODE needs a substitute path");
+                    tracing::info!(
+                        "TEST: sending {} in place of the consignment for funding \
+                         {funding_txid_str}",
+                        path.display()
+                    );
+                    path
+                } else {
+                    consignment_path
                 };
                 let consignment_bytes = fs::read(&consignment_path)
                     .expect("consignment we just generated must be readable");

--- a/src/ldk.rs
+++ b/src/ldk.rs
@@ -178,6 +178,59 @@ pub(crate) fn node_override_matches(
         .is_some_and(|id| *id == our_node_id)
 }
 
+// Test-only: the node with this pubkey puts an extra witness recipient of its own in front of the
+// channel output when it builds a colored funding transaction, so the channel output lands at vout
+// 2 instead of vout 1. Models a funding initiator that does not follow the one-recipient
+// convention: the funding transaction is built entirely by the initiator and LDK carries the
+// resulting index in `funding_created.funding_output_index`, so a peer is free to do this.
+#[cfg(test)]
+pub(crate) static DECOY_FUNDING_OUTPUT_ON_NODE: Mutex<Option<PublicKey>> = Mutex::new(None);
+
+// Test-only: the token RGB amount that goes to whichever of the two outputs is not meant to hold
+// the channel's assets when DECOY_FUNDING_OUTPUT_ON_NODE applies (rgb-lib rejects an assignment of
+// zero).
+#[cfg(test)]
+pub(crate) const DECOY_CHANNEL_ASSET_AMT: u64 = 1;
+
+// Test-only: which of the two outputs the channel's nominal RGB amount goes to when
+// DECOY_FUNDING_OUTPUT_ON_NODE applies. False (the default) leaves the assets on the channel
+// output and only moves its index; true keeps them on the initiator's own decoy output, so that
+// both peers agree on an RGB balance the funding output does not hold.
+#[cfg(test)]
+pub(crate) static DECOY_KEEPS_CHANNEL_ASSETS: AtomicBool = AtomicBool::new(false);
+
+// Test-only: satoshis paid to the decoy output built for DECOY_FUNDING_OUTPUT_ON_NODE
+#[cfg(test)]
+pub(crate) const DECOY_OUTPUT_SAT: u64 = 5_000;
+
+// Test-only: makes the decoy output built for DECOY_FUNDING_OUTPUT_ON_NODE pay the channel's own
+// script instead of a fresh wallet address, so the funding transaction would carry that script
+// twice — with a different value, which is the only shape in which the initiator's
+// `position(|o| o.script_pubkey == script_buf)` search and LDK's own script-and-value search can
+// disagree. Only has an effect together with DECOY_FUNDING_OUTPUT_ON_NODE.
+#[cfg(test)]
+pub(crate) static DECOY_REUSES_CHANNEL_SCRIPT: AtomicBool = AtomicBool::new(false);
+
+// Test-only: makes the decoy output built for DECOY_FUNDING_OUTPUT_ON_NODE receive an inflation
+// right instead of a fungible amount, so that the assignment the acceptor finds at its hard-coded
+// funding vout is one `handle_funding` has no arm for. Only meaningful for an IFA asset (rgb-lib
+// rejects an inflation-right recipient for any other schema) and only together with
+// DECOY_FUNDING_OUTPUT_ON_NODE.
+#[cfg(test)]
+pub(crate) static DECOY_INFLATION_ASSIGNMENT: AtomicBool = AtomicBool::new(false);
+
+// Test-only: the node with this pubkey sends the file named by SUBSTITUTE_CONSIGNMENT_PATH to its
+// counterparty in place of the consignment for the funding transaction it just built. Models a
+// peer that puts arbitrary bytes on the p2p link: the acceptor stores whatever arrives as
+// `consignment_{funding_txid}` and feeds it to `_accept_transfer` without ever having asked for
+// that particular consignment.
+#[cfg(test)]
+pub(crate) static SUBSTITUTE_CONSIGNMENT_ON_NODE: Mutex<Option<PublicKey>> = Mutex::new(None);
+
+// Test-only: the file SUBSTITUTE_CONSIGNMENT_ON_NODE sends instead of the real consignment
+#[cfg(test)]
+pub(crate) static SUBSTITUTE_CONSIGNMENT_PATH: Mutex<Option<PathBuf>> = Mutex::new(None);
+
 pub(crate) struct LdkBackgroundServices {
     stop_processing: Arc<AtomicBool>,
     peer_manager: Arc<PeerManager>,
@@ -811,16 +864,89 @@ async fn handle_ldk_events(
                 let recipient_id =
                     recipient_id_from_script_buf(script_buf.clone(), static_state.network);
 
-                let recipient_map = map! {
-                    asset_id.clone() => vec![Recipient {
-                        recipient_id: recipient_id.clone(),
-                        witness_data: Some(WitnessData {
-                            amount_sat: channel_value_satoshis,
-                            blinding: Some(STATIC_BLINDING),
+                #[cfg(test)]
+                let decoy_funding_output = DECOY_FUNDING_OUTPUT_ON_NODE
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .is_some_and(|id| *id == unlocked_state.channel_manager.get_our_node_id());
+                #[cfg(test)]
+                let (decoy_recipient, assignment) = if decoy_funding_output {
+                    let Assignment::Fungible(amount) = assignment else {
+                        panic!("TEST: the decoy funding output needs a fungible assignment")
+                    };
+                    let decoy_script = if DECOY_REUSES_CHANNEL_SCRIPT.load(Ordering::SeqCst) {
+                        script_buf.clone()
+                    } else {
+                        let unlocked_state_copy = unlocked_state.clone();
+                        let decoy_address = tokio::task::spawn_blocking(move || {
+                            unlocked_state_copy.rgb_get_address()
+                        })
+                        .await
+                        .unwrap()
+                        .unwrap();
+                        rgb_lib::bitcoin::Address::from_str(&decoy_address)
+                            .unwrap()
+                            .assume_checked()
+                            .script_pubkey()
+                    };
+                    let (decoy_amount, channel_amount) =
+                        if DECOY_KEEPS_CHANNEL_ASSETS.load(Ordering::SeqCst) {
+                            (amount, DECOY_CHANNEL_ASSET_AMT)
+                        } else {
+                            (DECOY_CHANNEL_ASSET_AMT, amount)
+                        };
+                    let decoy_assignment = if DECOY_INFLATION_ASSIGNMENT.load(Ordering::SeqCst) {
+                        Assignment::InflationRight(decoy_amount)
+                    } else {
+                        Assignment::Fungible(decoy_amount)
+                    };
+                    tracing::info!(
+                        "TEST: putting {decoy_assignment:?} of asset {asset_id} on a decoy output \
+                         to script {} ahead of the channel output, leaving {channel_amount} on \
+                         the channel output",
+                        decoy_script.to_hex_string()
+                    );
+                    (
+                        Some(Recipient {
+                            recipient_id: recipient_id_from_script_buf(
+                                decoy_script,
+                                static_state.network,
+                            ),
+                            witness_data: Some(WitnessData {
+                                amount_sat: DECOY_OUTPUT_SAT,
+                                blinding: Some(STATIC_BLINDING),
+                            }),
+                            assignment: decoy_assignment,
+                            transport_endpoints: vec![],
                         }),
-                        assignment,
-                        transport_endpoints: vec![]
-                }]};
+                        Assignment::Fungible(channel_amount),
+                    )
+                } else {
+                    (None, assignment)
+                };
+
+                let recipients: Vec<Recipient> = vec![Recipient {
+                    recipient_id: recipient_id.clone(),
+                    witness_data: Some(WitnessData {
+                        amount_sat: channel_value_satoshis,
+                        blinding: Some(STATIC_BLINDING),
+                    }),
+                    assignment,
+                    transport_endpoints: vec![],
+                }];
+                // the decoy is prepended, so the channel output no longer lands where an
+                // unhooked node would put it
+                #[cfg(test)]
+                let recipients = match decoy_recipient {
+                    Some(decoy) => {
+                        let mut with_decoy = vec![decoy];
+                        with_decoy.extend(recipients);
+                        with_decoy
+                    }
+                    None => recipients,
+                };
+                let recipient_map = map! { asset_id.clone() => recipients };
 
                 let unlocked_state_copy = unlocked_state.clone();
                 let res = tokio::task::spawn_blocking(move || {
@@ -934,6 +1060,30 @@ async fn handle_ldk_events(
                 // send the consignment to the channel counterparty over the encrypted p2p link
                 let consignment_path =
                     unlocked_state.rgb_get_send_consignment_path(&asset_id, &funding_txid_str);
+                #[cfg(test)]
+                let consignment_path = {
+                    let substitute = SUBSTITUTE_CONSIGNMENT_ON_NODE
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .is_some_and(|id| *id == unlocked_state.channel_manager.get_our_node_id())
+                        .then(|| {
+                            SUBSTITUTE_CONSIGNMENT_PATH.lock().unwrap().clone().expect(
+                                "TEST: SUBSTITUTE_CONSIGNMENT_ON_NODE needs a substitute path",
+                            )
+                        });
+                    match substitute {
+                        Some(path) => {
+                            tracing::info!(
+                                "TEST: sending {} to the counterparty instead of the consignment \
+                                 for funding {funding_txid_str}",
+                                path.display()
+                            );
+                            path
+                        }
+                        None => consignment_path,
+                    }
+                };
                 let consignment_bytes = fs::read(&consignment_path)
                     .expect("consignment we just generated must be readable");
                 if unlocked_state

--- a/src/test/accept_before_validate.rs
+++ b/src/test/accept_before_validate.rs
@@ -1,0 +1,724 @@
+//! The acceptor imports a consignment before validating its contents.
+//!
+//! `handle_funding` (`rust-lightning/lightning/src/rgb_utils/mod.rs:599`) is called from
+//! `internal_funding_created` (`channelmanager.rs:10504`) the moment a `funding_created` arrives,
+//! before `inbound_chan.funding_created(...)` has looked at the message. Its first act is
+//! `_accept_transfer` (`rgb_utils/mod.rs:157`), which hands the file the peer put on the p2p link
+//! to `wallet.accept_transfer_consignment(...)` — not a query: it `store_secret_seal`s,
+//! `import_contract`s and `accept_transfer`s into the acceptor's RGB stock
+//! (`rgb-lib-0.3.0-beta.7/src/wallet/rust_only.rs:328-406`).
+//!
+//! Only afterwards does `handle_funding` ask whether the consignment says anything about this
+//! channel:
+//!
+//! ```text
+//! 655    if remote_rgb_assignments.len() != 1 { ...close... }
+//! 661    let channel_rgb_amount = match remote_rgb_assignments[0] {
+//! 662        Assignment::Fungible(amt) => amt,
+//! 663        Assignment::NonFungible => 1,
+//! 664        _ => unreachable!("unsupported schema"),
+//! 665    };
+//! ```
+//!
+//! Both faults are injected on the *sender*: [`SUBSTITUTE_CONSIGNMENT_ON_NODE`] makes node1 put a
+//! different file on the p2p link, and [`DECOY_INFLATION_ASSIGNMENT`] makes the extra output
+//! [`DECOY_FUNDING_OUTPUT_ON_NODE`] already builds carry an inflation right. The acceptor is an
+//! unmodified node reacting to bytes a peer chose — and the peer is the one that builds the
+//! funding transaction and the consignment for it.
+
+use lightning::rgb_utils::parse_rgb_channel_info;
+
+use crate::ldk::{
+    DECOY_FUNDING_OUTPUT_ON_NODE, DECOY_INFLATION_ASSIGNMENT, DECOY_OUTPUT_SAT,
+    SUBSTITUTE_CONSIGNMENT_ON_NODE, SUBSTITUTE_CONSIGNMENT_PATH,
+};
+
+use super::repro_util::{
+    funding_psbt_outputs, print_outputs, snapshot_node_dir, DirSnapshot, TxOutput,
+};
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/accept_before_validate/";
+
+/// The funding vout `_accept_transfer` hard-codes, and therefore the one the acceptor looks for
+/// assignments at.
+const ACCEPTOR_ASSUMED_VOUT: usize = 1;
+
+const CHAN_ASSET_AMT: u64 = 400;
+
+/// Sent to a third party before the substituted-consignment run, purely to produce a valid
+/// consignment the acceptor has never seen.
+const DECOY_SEND_AMT: u64 = 100;
+
+/// Named so the tests can find the channel output by value.
+const CAPACITY_SAT: u64 = 100_000;
+
+/// How long to wait for a node to act on a message it has just been sent.
+const REACTION_TIMEOUT_SECS: f32 = 60.0;
+
+/// The RGB stock files, which is where `accept_transfer_consignment` writes. Their growth is the
+/// evidence that the wallet was mutated before the consignment's contents were looked at.
+fn stock_entries(snapshot: &DirSnapshot) -> Vec<(String, u64)> {
+    snapshot
+        .paths_matching(|p| p.contains("/rgb/") && p.ends_with(".dat"))
+        .into_iter()
+        .map(|p| {
+            let size = snapshot.get(&p).expect("path came from this snapshot").size;
+            (p, size)
+        })
+        .collect()
+}
+
+fn print_stock(label: &str, snapshot: &DirSnapshot) {
+    println!("{label}:");
+    for (path, size) in stock_entries(snapshot) {
+        println!("  {path}: {size} bytes");
+    }
+}
+
+/// Total bytes of the RGB stock, a single number to compare two snapshots by.
+fn stock_size(snapshot: &DirSnapshot) -> u64 {
+    stock_entries(snapshot).iter().map(|(_, size)| size).sum()
+}
+
+/// The consignment files a node holds in `.ldk/`, as `(relative path, sha256)`.
+fn consignments(snapshot: &DirSnapshot) -> Vec<(String, String)> {
+    snapshot
+        .paths_matching(|p| {
+            p.rsplit('/')
+                .next()
+                .unwrap_or(p)
+                .starts_with("consignment_")
+        })
+        .into_iter()
+        .map(|p| {
+            let hash = snapshot
+                .get(&p)
+                .expect("path came from this snapshot")
+                .sha256
+                .clone()
+                .expect("consignments are hashed by the snapshot");
+            (p, hash)
+        })
+        .collect()
+}
+
+/// Every `consignment_out` rgb-lib has written under a node's wallet directory. This is where the
+/// consignment for a completed send lives, and the file the substitution hook is pointed at.
+fn sent_consignment_files(node_test_dir: &str) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = walkdir::WalkDir::new(node_test_dir)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file() && e.file_name() == "consignment_out")
+        .map(|e| e.path().to_path_buf())
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// `(local, remote)` asset amounts a node recorded for `channel_id`, from either the pending or
+/// the final RGB channel-info file. `handle_funding` writes both, *after* the checks under test.
+fn rgb_amounts_on_disk(node_test_dir: &str, channel_id: &str) -> Option<(u64, u64)> {
+    let ldk_dir = PathBuf::from(node_test_dir).join(LDK_DIR);
+    for name in [channel_id.to_string(), format!("{channel_id}.pending")] {
+        let path = ldk_dir.join(name);
+        if path.exists() {
+            let info = parse_rgb_channel_info(&path);
+            return Some((info.local_rgb_amount, info.remote_rgb_amount));
+        }
+    }
+    None
+}
+
+/// `/assetbalance` for a node that may not know the contract at all. A refused open leaves the
+/// acceptor in exactly that state, so the plain helper (which panics on a non-200) cannot be used.
+async fn balance_or_error(node_address: SocketAddr, asset_id: &str) -> String {
+    let payload = AssetBalanceRequest {
+        asset_id: asset_id.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/assetbalance"))
+        .json(&payload)
+        .send()
+        .await
+        .unwrap();
+    if res.status() != reqwest::StatusCode::OK {
+        return format!("refused: {}", res.text().await.unwrap());
+    }
+    let b = res.json::<AssetBalanceResponse>().await.unwrap();
+    format!(
+        "settled {} / future {} / spendable {} / offchain_out {} / offchain_in {}",
+        b.settled, b.future, b.spendable, b.offchain_outbound, b.offchain_inbound
+    )
+}
+
+/// Whether `/assetbalance` answers at all, i.e. whether the node's rgb-lib **database** knows the
+/// contract. The RGB stock is a separate store, and the two can disagree.
+async fn db_knows_asset(node_address: SocketAddr, asset_id: &str) -> bool {
+    let payload = AssetBalanceRequest {
+        asset_id: asset_id.to_string(),
+    };
+    reqwest::Client::new()
+        .post(format!("http://{node_address}/assetbalance"))
+        .json(&payload)
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
+}
+
+/// Whether a node still answers `/listchannels`. A panic inside the `ChannelManager` poisons its
+/// locks, after which this stops being true.
+async fn channel_manager_alive(node_address: SocketAddr) -> bool {
+    reqwest::Client::new()
+        .get(format!("http://{node_address}/listchannels"))
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
+}
+
+async fn wait_for_dead_channel_manager(node_address: SocketAddr) -> bool {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        if !channel_manager_alive(node_address).await {
+            println!("node {node_address} no longer answers /listchannels");
+            return true;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > REACTION_TIMEOUT_SECS {
+            return false;
+        }
+        mine_n_blocks(false, 1);
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+/// Waits for `needle` to show up in a node's LDK log and returns the matching lines.
+async fn wait_for_ldk_log(node_test_dir: &str, needle: &str) -> Vec<String> {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        let matching: Vec<String> = ldk_log_lines(node_test_dir)
+            .into_iter()
+            .filter(|line| line.contains(needle))
+            .collect();
+        if !matching.is_empty() {
+            return matching;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > REACTION_TIMEOUT_SECS {
+            panic!("{node_test_dir} never logged {needle:?}");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+async fn wait_for_no_channels(node_address: SocketAddr) -> bool {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        if list_channels(node_address).await.is_empty() {
+            return true;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > REACTION_TIMEOUT_SECS {
+            return false;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+async fn channel_summaries(node_address: SocketAddr) -> Vec<String> {
+    list_channels(node_address)
+        .await
+        .iter()
+        .map(|c| {
+            format!(
+                "{} {:?} ready={} local={:?} remote={:?}",
+                c.channel_id, c.status, c.ready, c.asset_local_amount, c.asset_remote_amount
+            )
+        })
+        .collect()
+}
+
+/// Wait for the initiator to persist the funding PSBT and return the transaction it built. A
+/// funding the acceptor refuses is never broadcast, so the PSBT on disk is the only place it can
+/// be read from.
+async fn wait_for_funding_psbt(node_test_dir: &str) -> (String, Vec<TxOutput>) {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        let psbt_written = std::fs::read_dir(PathBuf::from(node_test_dir).join(LDK_DIR))
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .any(|e| e.file_name().to_string_lossy().starts_with("psbt_"))
+            })
+            .unwrap_or(false);
+        if psbt_written {
+            return funding_psbt_outputs(node_test_dir);
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > REACTION_TIMEOUT_SECS {
+            panic!("{node_test_dir} never persisted a funding PSBT");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+/// The index of the only P2WSH output worth `capacity_sat` — the channel output — found without
+/// assuming anything about the layout.
+fn channel_output_index(outputs: &[TxOutput], capacity_sat: u64) -> u16 {
+    let matches: Vec<u16> = outputs
+        .iter()
+        .filter(|o| o.script_type == "witness_v0_scripthash" && o.sats == capacity_sat)
+        .map(|o| o.index as u16)
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one P2WSH output of {capacity_sat} sat, got {matches:?}"
+    );
+    matches[0]
+}
+
+/// Resets [`DECOY_INFLATION_ASSIGNMENT`] on drop, so a panicking test cannot leak it into the
+/// next one.
+struct InflationDecoyGuard;
+
+impl InflationDecoyGuard {
+    fn set() -> Self {
+        DECOY_INFLATION_ASSIGNMENT.store(true, Ordering::SeqCst);
+        Self
+    }
+}
+
+impl Drop for InflationDecoyGuard {
+    fn drop(&mut self) {
+        DECOY_INFLATION_ASSIGNMENT.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Points [`SUBSTITUTE_CONSIGNMENT_ON_NODE`] at a node and a file, and clears both on drop.
+struct SubstituteConsignmentGuard(#[allow(dead_code)] NodeOverrideGuard);
+
+impl SubstituteConsignmentGuard {
+    fn set(node_pubkey: &str, path: &Path) -> Self {
+        *SUBSTITUTE_CONSIGNMENT_PATH.lock().unwrap() = Some(path.to_path_buf());
+        Self(NodeOverrideGuard::set(
+            &SUBSTITUTE_CONSIGNMENT_ON_NODE,
+            node_pubkey,
+        ))
+    }
+}
+
+impl Drop for SubstituteConsignmentGuard {
+    fn drop(&mut self) {
+        // the node override goes first: the inner `NodeOverrideGuard` only runs after this body,
+        // so clearing the path first would leave a window where the node is still flagged as a
+        // substituter with no path, which the `FundingGenerationReady` handler `expect`s on
+        *SUBSTITUTE_CONSIGNMENT_ON_NODE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
+        *SUBSTITUTE_CONSIGNMENT_PATH
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = None;
+    }
+}
+
+/// Baseline: a successful colored open, so the state the rejection runs leave on the acceptor can
+/// be told apart from what every open produces. The acceptor imports the contract on the happy
+/// path too — the difference is whether a channel backs the import.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn baseline_a_good_open_imports_the_contract_and_keeps_the_channel() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}baseline/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    let before = snapshot_node_dir("node2 before the open", &test_dir_node2);
+    print_stock("node2 RGB stock before", &before);
+    assert!(
+        !db_knows_asset(node2_addr, &asset_id).await,
+        "the acceptor starts out not knowing the contract"
+    );
+
+    let channel = open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(CAPACITY_SAT),
+        None,
+        Some(CHAN_ASSET_AMT),
+        Some(&asset_id),
+    )
+    .await;
+
+    let after = snapshot_node_dir("node2 after the open", &test_dir_node2);
+    println!("\n=== node2 (acceptor), successful open ===");
+    before.diff(&after).rgb_only().print();
+    print_stock("node2 RGB stock after", &after);
+    println!(
+        "node2 balance after: {}",
+        balance_or_error(node2_addr, &asset_id).await
+    );
+    println!("node2 consignments after: {:?}", consignments(&after));
+
+    assert!(channel.ready, "the baseline channel should be ready");
+    assert_eq!(
+        list_channels(node2_addr).await[0].asset_remote_amount,
+        Some(CHAN_ASSET_AMT),
+        "the acceptor credits the channel with what was actually sent"
+    );
+
+    // the acceptor's RGB stock grows on the happy path too, so growth by itself proves nothing —
+    // what the rejection runs add is growth with no channel to show for it
+    assert!(
+        stock_size(&after) > stock_size(&before),
+        "the acceptor imports the contract when it accepts the funding consignment"
+    );
+    // and here the import is backed by a channel and by an rgb-lib database that agrees
+    assert!(
+        db_knows_asset(node2_addr, &asset_id).await,
+        "after a successful open the acceptor's database knows the contract"
+    );
+    assert_eq!(
+        asset_balance(node2_addr, &asset_id).await.offchain_inbound,
+        CHAN_ASSET_AMT
+    );
+
+    shutdown(&[node1_addr, node2_addr]).await;
+}
+
+/// node1 first makes an ordinary on-chain send to node3, which leaves a valid consignment on its
+/// disk. It then opens a colored channel to node2 and puts *that* file on the p2p link instead of
+/// the one for its funding transaction. The consignment is valid, so `accept_transfer_consignment`
+/// succeeds and mutates node2's wallet; only afterwards does `handle_funding` notice it assigns
+/// nothing to the funding output.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn acceptor_imports_an_unrelated_consignment_before_rejecting_the_funding() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}substituted/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let test_dir_node3 = format!("{test_dir_base}node3");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+    let (node3_addr, _) = start_node(&test_dir_node3, NODE3_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+    fund_and_create_utxos(node3_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let node1_pubkey = node_info(node1_addr).await.pubkey;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    // an ordinary send to a third party, only so that node1 ends up holding a consignment that is
+    // valid and that node2 has never seen
+    println!("\n=== node1 sends {DECOY_SEND_AMT} to node3, to mint a spare consignment ===");
+    let recipient_id = rgb_invoice(node3_addr, None, false).await.recipient_id;
+    send_asset(
+        node1_addr,
+        &asset_id,
+        Assignment::Fungible(DECOY_SEND_AMT),
+        recipient_id,
+        None,
+    )
+    .await;
+    mine(false);
+    refresh_transfers(node3_addr).await;
+    refresh_transfers(node3_addr).await;
+    refresh_transfers(node1_addr).await;
+    assert_eq!(
+        asset_balance_spendable(node3_addr, &asset_id).await,
+        DECOY_SEND_AMT
+    );
+
+    let spare_consignments = sent_consignment_files(&test_dir_node1);
+    println!(
+        "node1 holds {} sent consignment(s):",
+        spare_consignments.len()
+    );
+    for path in &spare_consignments {
+        println!("  {}", path.display());
+    }
+    let spare = spare_consignments
+        .first()
+        .expect("the send to node3 left a consignment on node1's disk")
+        .clone();
+    let spare_sha = Sha256::hash(&std::fs::read(&spare).unwrap()).to_string();
+    println!("substituting {} (sha256 {spare_sha})", spare.display());
+
+    let before = snapshot_node_dir("node2 before the substituted open", &test_dir_node2);
+    print_stock("node2 RGB stock before", &before);
+    assert!(!db_knows_asset(node2_addr, &asset_id).await);
+
+    let temporary_channel_id = {
+        let _substitute = SubstituteConsignmentGuard::set(&node1_pubkey, &spare);
+        let temporary_channel_id = open_channel_raw(
+            node1_addr,
+            &node2_pubkey,
+            Some(NODE2_PEER_PORT),
+            Some(CAPACITY_SAT),
+            None,
+            Some(CHAN_ASSET_AMT),
+            Some(&asset_id),
+            None,
+            None,
+            None,
+            None,
+            true,
+            true,
+        )
+        .await
+        .expect("the open request itself is accepted")
+        .temporary_channel_id;
+
+        let rejection =
+            wait_for_ldk_log(&test_dir_node2, "Unexpected number of RGB assignments: 0").await;
+        println!("\nnode2 rejection: {rejection:#?}");
+        temporary_channel_id
+    };
+
+    let after = snapshot_node_dir("node2 after the substituted open", &test_dir_node2);
+    println!("\n=== node2 (acceptor), substituted consignment ===");
+    before.diff(&after).rgb_only().print();
+    print_stock("node2 RGB stock after", &after);
+    let held = consignments(&after);
+    println!("node2 consignments after: {held:?}");
+    println!(
+        "node2 balance after: {}",
+        balance_or_error(node2_addr, &asset_id).await
+    );
+    println!(
+        "node2 RGB channel info for {temporary_channel_id}: {:?}",
+        rgb_amounts_on_disk(&test_dir_node2, &temporary_channel_id)
+    );
+
+    // EXPECTED AFTER FIX: the acceptor validates the consignment before importing, so it never
+    // stores the unrelated file node1 substituted onto the p2p link
+    // 1. the acceptor must NOT be holding the attacker's bytes
+    assert!(
+        held.iter().all(|(_, sha)| *sha != spare_sha),
+        "node2 must not be holding the unrelated file node1 sent; the consignment must be validated before it is imported"
+    );
+
+    // 2. and it ran it through its wallet before looking at it: the RGB stock grew
+    println!(
+        "node2 stock: {} -> {} bytes",
+        stock_size(&before),
+        stock_size(&after)
+    );
+    // EXPECTED AFTER FIX: the assignment check runs before `_accept_transfer`, so a consignment that
+    // says nothing about the funding output is rejected without ever mutating the acceptor's stock
+    assert!(
+        stock_size(&after) == stock_size(&before),
+        "the acceptor must not import the contract before the assignment check has accepted the funding"
+    );
+
+    // 3. the check then fired, so the channel never came up and nothing was bound to it
+    assert!(
+        wait_for_no_channels(node2_addr).await,
+        "the acceptor must not keep a channel whose consignment says nothing about it"
+    );
+    assert_eq!(
+        rgb_amounts_on_disk(&test_dir_node2, &temporary_channel_id),
+        None,
+        "the assignment check runs before `write_rgb_channel_info`, so no RGB info is written"
+    );
+
+    // 4. the node survives — this is a close, not a panic
+    assert!(
+        channel_manager_alive(node2_addr).await,
+        "a zero-assignment consignment closes the channel rather than killing the node"
+    );
+
+    // EXPECTED AFTER FIX: a rejected open leaves neither store knowing the contract, so they agree
+    assert!(
+        !db_knows_asset(node2_addr, &asset_id).await,
+        "a rejected open must leave the acceptor's database not knowing the contract"
+    );
+
+    println!("\n=== restarting node2 to see what survives ===");
+    shutdown(&[node2_addr]).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, true).await;
+    let restarted = snapshot_node_dir("node2 after a restart", &test_dir_node2);
+    println!(
+        "node2 consignments after the restart: {:?}",
+        consignments(&restarted)
+    );
+    println!(
+        "node2 balance after the restart: {}",
+        balance_or_error(node2_addr, &asset_id).await
+    );
+    // EXPECTED AFTER FIX: a refused funding leaves no consignment residue, even across a restart
+    assert!(
+        consignments(&restarted)
+            .iter()
+            .all(|(_, sha)| *sha != spare_sha),
+        "a refused funding must leave no unrelated consignment on the acceptor, even across a restart"
+    );
+    // EXPECTED AFTER FIX: nothing was imported, so no contract residue survives a restart either
+    assert!(
+        stock_size(&restarted) <= stock_size(&before),
+        "a refused funding must leave no imported contract on the acceptor, even across a restart"
+    );
+
+    // and the practical damage test: can this acceptor still take a real channel for this asset?
+    println!("\n=== a good open for the same asset, after the rejection ===");
+    let good = open_channel(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(CAPACITY_SAT),
+        None,
+        Some(CHAN_ASSET_AMT),
+        Some(&asset_id),
+    )
+    .await;
+    println!("node2 channels: {:?}", channel_summaries(node2_addr).await);
+    assert!(
+        good.ready,
+        "the leftover state must not block a later channel for the same asset"
+    );
+    assert_eq!(
+        list_channels(node2_addr).await[0].asset_remote_amount,
+        Some(CHAN_ASSET_AMT)
+    );
+    assert_eq!(
+        asset_balance(node2_addr, &asset_id).await.offchain_inbound,
+        CHAN_ASSET_AMT,
+        "and the acceptor's balance is the channel's, not the channel's plus the accepted transfer"
+    );
+
+    shutdown(&[node1_addr, node2_addr, node3_addr]).await;
+}
+
+/// `remote_rgb_assignments[0]` is matched with `_ => unreachable!("unsupported schema")`, and
+/// `Assignment` has four variants.
+///
+/// node1 issues an IFA asset — the one schema that has inflation rights — and puts an
+/// `InflationRight` on an output of its own placed in front of the channel output, so the
+/// assignment the acceptor finds at its hard-coded vout 1 is one the match has no arm for. The
+/// channel output itself keeps a proper fungible amount, which is what lets the initiator colour
+/// its own commitment and get as far as sending `funding_created`.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn unsupported_assignment_variant_panics_the_acceptor() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}inflation_decoy/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_ifa(node1_addr).await.asset_id;
+    let node1_pubkey = node_info(node1_addr).await.pubkey;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    println!(
+        "node1 balance: {}",
+        balance_or_error(node1_addr, &asset_id).await
+    );
+
+    let before = snapshot_node_dir("node2 before the open", &test_dir_node2);
+    print_stock("node2 RGB stock before", &before);
+
+    let _decoy = NodeOverrideGuard::set(&DECOY_FUNDING_OUTPUT_ON_NODE, &node1_pubkey);
+    let _inflation = InflationDecoyGuard::set();
+
+    println!("\nopening an IFA channel with an inflation right on the output in front of it");
+    let temporary_channel_id = open_channel_raw(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(CAPACITY_SAT),
+        None,
+        Some(CHAN_ASSET_AMT),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        None,
+        true,
+        true,
+    )
+    .await
+    .expect("the open request itself is accepted")
+    .temporary_channel_id;
+
+    let (funding_txid, outputs) = wait_for_funding_psbt(&test_dir_node1).await;
+    let index = channel_output_index(&outputs, CAPACITY_SAT);
+    print_outputs("funding transaction", &funding_txid, &outputs, Some(index));
+    assert!(outputs[0].is_op_return());
+    assert_eq!(
+        outputs[ACCEPTOR_ASSUMED_VOUT].sats, DECOY_OUTPUT_SAT,
+        "vout {ACCEPTOR_ASSUMED_VOUT} carries the inflation right, not the channel"
+    );
+    assert_eq!(
+        index, 2,
+        "the channel output, which holds the fungible amount, is at vout 2"
+    );
+
+    // EXPECTED AFTER FIX: the acceptor reaches `handle_funding`, finds an assignment variant it has
+    // no channel use for, and rejects the funding cleanly instead of hitting `unreachable!` — so its
+    // `ChannelManager` never panics and keeps answering.
+    assert!(
+        !wait_for_dead_channel_manager(node2_addr).await,
+        "an assignment variant the match has no arm for must be rejected cleanly, not crash the acceptor's ChannelManager"
+    );
+
+    let after = snapshot_node_dir("node2 after the panic", &test_dir_node2);
+    println!("\n=== node2 (acceptor), inflation-right assignment ===");
+    before.diff(&after).rgb_only().print();
+    print_stock("node2 RGB stock after", &after);
+    println!("node2 consignments after: {:?}", consignments(&after));
+    println!(
+        "node2 RGB channel info for {temporary_channel_id}: {:?}",
+        rgb_amounts_on_disk(&test_dir_node2, &temporary_channel_id)
+    );
+    println!(
+        "node1 channels: {:?}\nnode1 balance: {}",
+        channel_summaries(node1_addr).await,
+        balance_or_error(node1_addr, &asset_id).await
+    );
+
+    // the wallet mutation happened before the panic, exactly as in the zero-assignment run
+    // EXPECTED AFTER FIX: the assignment variant is checked before `_accept_transfer`, so a rejected
+    // funding leaves the acceptor's stock unchanged
+    assert!(
+        stock_size(&after) == stock_size(&before),
+        "the acceptor must not import the consignment before the assignment variant has been accepted"
+    );
+    // EXPECTED AFTER FIX: a rejected funding writes no RGB channel info
+    assert_eq!(
+        rgb_amounts_on_disk(&test_dir_node2, &temporary_channel_id),
+        None,
+        "a rejected funding must leave no RGB channel info bound to the channel"
+    );
+    // EXPECTED AFTER FIX: a rejected funding leaves no consignment residue on the acceptor
+    assert!(
+        consignments(&after).is_empty(),
+        "a rejected funding must leave no consignment on the acceptor's disk"
+    );
+
+    // the initiator is not the one that misbehaved from LDK's point of view; it stays alive
+    assert!(
+        channel_manager_alive(node1_addr).await,
+        "the initiator survives the rejected open"
+    );
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2358,6 +2358,7 @@ pub fn mock_fee(fee: u32) -> u32 {
     }
 }
 
+mod accept_before_validate;
 mod authentication;
 mod backup_and_restore;
 mod close_coop_nobtc_acceptor;
@@ -2393,8 +2394,10 @@ mod openchannel_optional_addr;
 mod openchannel_push_asset_amount;
 mod out_of_band;
 mod payment;
+mod push_asset_amount;
 mod push_asset_amount_above_chan_amt;
 mod refuse_high_fees;
+mod repro_util;
 mod restart;
 mod send_receive;
 mod swap_assets_liquidity_both_ways;

--- a/src/test/push_asset_amount.rs
+++ b/src/test/push_asset_amount.rs
@@ -1,0 +1,503 @@
+//! A peer-supplied `push_asset_amount` must be validated on the acceptor.
+//!
+//! `push_asset_amount` rides on `open_channel` as part of the RGB TLV
+//! (`rgb_asset: Option<(ContractId, Option<u64>)>` in `rust-lightning/lightning/src/ln/msgs.rs`).
+//! The acceptor stores it verbatim on the inbound channel and reads it back in `handle_funding`
+//! (`rgb_utils/mod.rs`), where `channel_rgb_amount.checked_sub(push_amount)` rejects a push
+//! larger than what the funding output holds. It used to be an unchecked subtraction that
+//! panicked the peer-message path (debug) or wrapped (release); these tests keep that covered.
+//! The only other check lives in the *sender's* REST layer, so the sender has to be hostile to
+//! reach the acceptor-side one.
+//!
+//! The fault is injected with [`FORCE_PUSH_ASSET_AMOUNT_ON_NODE`]: the named node puts
+//! `asset_amount + 1` on the wire while its own channel accounting keeps the honest value — the
+//! freedom any peer has, since the guard that would have stopped it runs on the sender, in code
+//! a hostile peer is not running. Nothing is patched on the victim.
+
+use lightning::rgb_utils::parse_rgb_channel_info;
+
+use crate::ldk::FORCE_PUSH_ASSET_AMOUNT_ON_NODE;
+
+use super::repro_util::snapshot_node_dir;
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/push_asset_amount/";
+
+/// RGB amount the channel is funded with — what the consignment really assigns to the funding
+/// output, and what the acceptor's `channel_rgb_amount` is.
+const CHAN_ASSET_AMT: u64 = 600;
+
+/// A legal push, used for the baseline run.
+const HONEST_PUSH: u64 = 250;
+
+/// An oversized push for the REST-guard check; the wire-level hostile push is
+/// `CHAN_ASSET_AMT + 1`, hard-coded by [`FORCE_PUSH_ASSET_AMOUNT_ON_NODE`].
+const HOSTILE_PUSH: u64 = 1_000;
+
+const CAPACITY_SAT: u64 = 100_000;
+
+/// How long to wait for a node to act on a message it has just been sent.
+const REACTION_TIMEOUT_SECS: f32 = 90.0;
+
+/// RGB channel info is written to `.ldk/<channel_id>` and `.ldk/<channel_id>.pending`. Both the
+/// temporary and the final channel ID can name one, so a scenario that does not know which ID a
+/// node settled on reads them all.
+fn channel_info_files(node_test_dir: &str) -> Vec<(String, u64, u64)> {
+    let ldk_dir = PathBuf::from(node_test_dir).join(LDK_DIR);
+    let Ok(entries) = std::fs::read_dir(&ldk_dir) else {
+        return vec![];
+    };
+    let mut infos: Vec<(String, u64, u64)> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            let stem = name.strip_suffix(".pending").unwrap_or(&name);
+            if stem.len() != 64 || !stem.chars().all(|c| c.is_ascii_hexdigit()) {
+                return None;
+            }
+            let info = parse_rgb_channel_info(&e.path());
+            Some((name, info.local_rgb_amount, info.remote_rgb_amount))
+        })
+        .collect();
+    infos.sort();
+    infos
+}
+
+/// `(local, remote)` asset amounts a node recorded for `channel_id` in `.ldk/<channel_id>`,
+/// falling back to the `.pending` file the acceptor writes first.
+fn rgb_amounts_on_disk(node_test_dir: &str, channel_id: &str) -> Option<(u64, u64)> {
+    let ldk_dir = PathBuf::from(node_test_dir).join(LDK_DIR);
+    for name in [channel_id.to_string(), format!("{channel_id}.pending")] {
+        let path = ldk_dir.join(name);
+        if path.exists() {
+            let info = parse_rgb_channel_info(&path);
+            return Some((info.local_rgb_amount, info.remote_rgb_amount));
+        }
+    }
+    None
+}
+
+/// Whether a node still answers `/listchannels`. A panic inside the `ChannelManager` poisons its
+/// locks, after which this stops being true.
+async fn channel_manager_alive(node_address: SocketAddr) -> bool {
+    reqwest::Client::new()
+        .get(format!("http://{node_address}/listchannels"))
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
+}
+
+async fn wait_for_dead_channel_manager(node_address: SocketAddr) -> bool {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        if !channel_manager_alive(node_address).await {
+            println!("node {node_address} no longer answers /listchannels");
+            return true;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > REACTION_TIMEOUT_SECS {
+            return false;
+        }
+        mine_n_blocks(false, 1);
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+/// `/listchannels`, tolerating a node whose `ChannelManager` no longer answers.
+async fn channel_summaries(node_address: SocketAddr) -> Vec<String> {
+    let res = reqwest::Client::new()
+        .get(format!("http://{node_address}/listchannels"))
+        .send()
+        .await;
+    let Ok(res) = res else {
+        return vec![s!("<node does not answer /listchannels>")];
+    };
+    if !res.status().is_success() {
+        return vec![format!("<listchannels failed: {}>", res.status())];
+    }
+    res.json::<ListChannelsResponse>()
+        .await
+        .map(|r| {
+            r.channels
+                .iter()
+                .map(|c| {
+                    format!(
+                        "{} ready={} local_asset={:?} remote_asset={:?} status={:?}",
+                        c.channel_id,
+                        c.ready,
+                        c.asset_local_amount,
+                        c.asset_remote_amount,
+                        c.status
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_else(|e| vec![format!("<unparseable listchannels: {e}>")])
+}
+
+/// `/assetbalance` for a node that may not know the contract, or may be dead.
+async fn balance_line(node_address: SocketAddr, asset_id: &str) -> String {
+    let payload = AssetBalanceRequest {
+        asset_id: asset_id.to_string(),
+    };
+    let res = reqwest::Client::new()
+        .post(format!("http://{node_address}/assetbalance"))
+        .json(&payload)
+        .send()
+        .await;
+    let Ok(res) = res else {
+        return s!("<node does not answer /assetbalance>");
+    };
+    if !res.status().is_success() {
+        return format!("refused: {}", res.text().await.unwrap_or_default());
+    }
+    match res.json::<AssetBalanceResponse>().await {
+        Ok(b) => format!(
+            "settled {} / future {} / spendable {} / offchain_out {} / offchain_in {}",
+            b.settled, b.future, b.spendable, b.offchain_outbound, b.offchain_inbound
+        ),
+        Err(e) => format!("<unparseable balance: {e}>"),
+    }
+}
+
+/// The funding transaction a node built for its pending channel, and whether it ever reached the
+/// mempool. `None` means the node never got as far as naming one.
+async fn funding_broadcast_state(node_address: SocketAddr) -> Option<(String, bool)> {
+    let res = reqwest::Client::new()
+        .get(format!("http://{node_address}/listchannels"))
+        .send()
+        .await
+        .ok()?;
+    let channels = res.json::<ListChannelsResponse>().await.ok()?.channels;
+    let txid = channels.into_iter().find_map(|c| c.funding_txid)?;
+    let in_mempool = !get_txout(&txid).is_empty();
+    Some((txid, in_mempool))
+}
+
+/// Panic messages raised anywhere in the process while a [`PanicCapture`] is installed. The nodes
+/// run in-process, so a panic on a node's peer-message path lands here rather than in its LDK log
+/// or in the tracing output — and *which* panic fires is the whole difference between the two
+/// build profiles.
+static CAPTURED_PANICS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+/// The panic hook that was installed before a [`PanicCapture`] took over.
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send>;
+
+/// Records every panic message for the lifetime of the guard, chaining to the hook that was
+/// installed before so the test harness still reports failures normally.
+struct PanicCapture {
+    previous: Option<std::sync::Arc<PanicHook>>,
+}
+
+impl PanicCapture {
+    fn install() -> Self {
+        CAPTURED_PANICS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clear();
+        let previous = std::sync::Arc::new(std::panic::take_hook());
+        let chained = previous.clone();
+        std::panic::set_hook(Box::new(move |info| {
+            CAPTURED_PANICS
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(format!("{info}"));
+            chained(info);
+        }));
+        Self {
+            previous: Some(previous),
+        }
+    }
+
+    fn messages() -> Vec<String> {
+        CAPTURED_PANICS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// The first captured panic mentioning `needle`, if any.
+    fn matching(needle: &str) -> Option<String> {
+        Self::messages().into_iter().find(|m| m.contains(needle))
+    }
+}
+
+impl Drop for PanicCapture {
+    fn drop(&mut self) {
+        // `take_hook`/`set_hook` abort the process when called from a panicking thread, and a
+        // failing assertion in a test that holds one of these is exactly that thread. Leaving the
+        // hook installed is harmless: it chains to the one it replaced and `install` clears the log.
+        if std::thread::panicking() {
+            return;
+        }
+        let _ = std::panic::take_hook();
+        if let Some(previous) = self.previous.take() {
+            match std::sync::Arc::try_unwrap(previous) {
+                Ok(hook) => std::panic::set_hook(hook),
+                Err(shared) => std::panic::set_hook(Box::new(move |info| shared(info))),
+            }
+        }
+    }
+}
+
+fn print_panics(label: &str) {
+    let messages = PanicCapture::messages();
+    println!("{label}: {} panic(s)", messages.len());
+    for message in &messages {
+        for line in message.lines() {
+            println!("  {line}");
+        }
+    }
+}
+
+fn print_ldk_tail(label: &str, node_test_dir: &str, needle: &str) {
+    let lines: Vec<String> = ldk_log_lines(node_test_dir)
+        .into_iter()
+        .filter(|l| l.contains(needle))
+        .collect();
+    println!("{label} ({} line(s) matching {needle:?}):", lines.len());
+    for line in lines.iter().rev().take(10).rev() {
+        println!("  {line}");
+    }
+}
+
+/// Baseline: the sender's REST guard refuses an oversized push at request level, and a legal
+/// push produces the split both sides agree on.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn baseline_rest_guard_refuses_oversized_push_and_a_legal_push_splits() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}baseline/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    // the guard: with the hook unset, the initiator refuses to send a push it cannot back
+    println!("\n=== the sender's own REST guard, hook unset ===");
+    let refused = open_channel_raw(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(CAPACITY_SAT),
+        None,
+        Some(CHAN_ASSET_AMT),
+        Some(&asset_id),
+        Some(HOSTILE_PUSH),
+        None,
+        None,
+        None,
+        true,
+        true,
+    )
+    .await;
+    let response = refused.expect_err("the REST guard rejects a push larger than the amount");
+    check_response_is_nok(
+        *response,
+        reqwest::StatusCode::BAD_REQUEST,
+        "Invalid amount: push_asset_amount cannot be higher than asset_amount",
+        "InvalidAmount",
+    )
+    .await;
+    assert!(
+        list_channels(node1_addr).await.is_empty(),
+        "the refused request must not have created a channel"
+    );
+    assert!(list_channels(node2_addr).await.is_empty());
+
+    // the legal case, for comparison: the acceptor's `channel_rgb_amount - push_amount` with a
+    // push the channel can actually back
+    println!("\n=== a legal push of {HONEST_PUSH} out of {CHAN_ASSET_AMT} ===");
+    let channel = open_channel_with_custom_data(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(CAPACITY_SAT),
+        None,
+        Some(CHAN_ASSET_AMT),
+        Some(&asset_id),
+        Some(HONEST_PUSH),
+        None,
+        None,
+        None,
+        true,
+    )
+    .await;
+
+    let node1_amounts = rgb_amounts_on_disk(&test_dir_node1, &channel.channel_id);
+    let node2_amounts = rgb_amounts_on_disk(&test_dir_node2, &channel.channel_id);
+    println!("node1 (initiator) RGB channel info: {node1_amounts:?}");
+    println!("node2 (acceptor)  RGB channel info: {node2_amounts:?}");
+    println!("node1 channels: {:?}", channel_summaries(node1_addr).await);
+    println!("node2 channels: {:?}", channel_summaries(node2_addr).await);
+
+    assert_eq!(
+        node1_amounts,
+        Some((CHAN_ASSET_AMT - HONEST_PUSH, HONEST_PUSH)),
+        "the initiator keeps what it did not push"
+    );
+    assert_eq!(
+        node2_amounts,
+        Some((HONEST_PUSH, CHAN_ASSET_AMT - HONEST_PUSH)),
+        "the acceptor's arithmetic on a legal push: local = push, remote = amount - push"
+    );
+
+    // and the two sides' books add up to the amount the funding output holds
+    let (node2_local, node2_remote) = node2_amounts.unwrap();
+    assert_eq!(
+        node2_local + node2_remote,
+        CHAN_ASSET_AMT,
+        "on the happy path the acceptor's two amounts sum to the channel's asset amount"
+    );
+}
+
+/// node1 sends an `open_channel` whose `push_asset_amount` exceeds the RGB amount its
+/// consignment assigns to the funding output; node2 must reject it cleanly, leaving no RGB
+/// residue and taking neither node down.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn acceptor_takes_an_inflated_push_asset_amount_from_a_hostile_peer() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}inflated_push/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let node1_pubkey = node_info(node1_addr).await.pubkey;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    let node2_before = snapshot_node_dir("node2 before the open", &test_dir_node2);
+    println!(
+        "\nnode1 balance before: {}",
+        balance_line(node1_addr, &asset_id).await
+    );
+    println!(
+        "node2 balance before: {}",
+        balance_line(node2_addr, &asset_id).await
+    );
+
+    println!(
+        "\n=== node1 opens a {CHAN_ASSET_AMT}-asset channel but claims to push {} ===",
+        CHAN_ASSET_AMT + 1
+    );
+    let _panics = PanicCapture::install();
+    let _hostile = NodeOverrideGuard::set(&FORCE_PUSH_ASSET_AMOUNT_ON_NODE, &node1_pubkey);
+
+    // the request itself is honest — no push at all — so the sender's REST guard has nothing to
+    // object to; only the message on the wire carries the inflated value
+    let temporary_channel_id = open_channel_raw(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        Some(CAPACITY_SAT),
+        None,
+        Some(CHAN_ASSET_AMT),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        None,
+        true,
+        true,
+    )
+    .await
+    .expect("the open request itself is accepted")
+    .temporary_channel_id;
+    println!("temporary channel id: {temporary_channel_id}");
+
+    // Either way the acceptor dies on the peer-message path, with the `ChannelManager`'s
+    // `per_peer_state` and `PeerState` locks held: `handle_funding` runs inside
+    // `internal_funding_created`. What differs between the profiles is *where*, and therefore what
+    // the acceptor has already persisted by then.
+    let died = wait_for_dead_channel_manager(node2_addr).await;
+
+    let node2_after = snapshot_node_dir("node2 after the inflated open", &test_dir_node2);
+    println!("\n=== node2 (acceptor) data dir ===");
+    node2_before.diff(&node2_after).rgb_only().print();
+    let node1_infos = channel_info_files(&test_dir_node1);
+    let node2_infos = channel_info_files(&test_dir_node2);
+    println!("node1 RGB channel info files: {node1_infos:?}");
+    println!("node2 RGB channel info files: {node2_infos:?}");
+    println!("node1 channels: {:?}", channel_summaries(node1_addr).await);
+    println!("node2 channels: {:?}", channel_summaries(node2_addr).await);
+    println!(
+        "node1 funding transaction: {:?}",
+        funding_broadcast_state(node1_addr).await
+    );
+    println!(
+        "node1 balance after: {}",
+        balance_line(node1_addr, &asset_id).await
+    );
+    println!(
+        "node2 balance after: {}",
+        balance_line(node2_addr, &asset_id).await
+    );
+    print_ldk_tail("node2 log", &test_dir_node2, "funding");
+    print_panics("panics raised while the open was in flight");
+
+    // the acceptor validates push_asset_amount and rejects the open cleanly, never panicking
+    // under its ChannelManager locks
+    assert!(
+        !died,
+        "an oversized peer-supplied amount must not take the acceptor's ChannelManager down"
+    );
+    assert!(
+        PanicCapture::matching("PoisonError").is_none(),
+        "the acceptor must not panic/poison its ChannelManager locks: {:?}",
+        PanicCapture::messages()
+    );
+
+    // a clean rejection takes neither node down
+    assert!(
+        channel_manager_alive(node1_addr).await,
+        "the initiator survives the clean rejection"
+    );
+    // the inflated open never becomes a live channel on the initiator either: the acceptor
+    // rejects it, so no channel opens ready with mis-accounted assets
+    let node1_channels = channel_summaries(node1_addr).await;
+    assert!(
+        !node1_channels.iter().any(|c| c.contains("ready=true")),
+        "the inflated open must not have opened a ready channel on the initiator: {node1_channels:?}"
+    );
+    // the initiator's own books stay honest — the lie only ever lived on the wire
+    assert!(
+        node1_infos
+            .iter()
+            .all(|(_, local, remote)| (*local, *remote) == (CHAN_ASSET_AMT, 0)),
+        "the initiator's own books stayed honest: {node1_infos:?}"
+    );
+    // the funding transaction is never broadcast, so the reserved UTXO returns to the wallet
+    let funding = funding_broadcast_state(node1_addr).await;
+    assert!(
+        funding.as_ref().map_or(true, |(_, in_mempool)| !*in_mempool),
+        "the funding transaction must not be broadcast for a rejected open: {funding:?}"
+    );
+
+    // the acceptor rejects the inflated push before writing RGB channel info, so no build
+    // profile persists a bad split
+    assert_eq!(
+        rgb_amounts_on_disk(&test_dir_node2, &temporary_channel_id),
+        None,
+        "the acceptor must not persist any RGB split for the rejected inflated open"
+    );
+    assert!(
+        node2_infos.is_empty(),
+        "the acceptor must record no RGB channel info for the inflated open: {node2_infos:?}"
+    );
+}

--- a/src/test/push_asset_amount.rs
+++ b/src/test/push_asset_amount.rs
@@ -485,7 +485,7 @@ async fn acceptor_takes_an_inflated_push_asset_amount_from_a_hostile_peer() {
     // the funding transaction is never broadcast, so the reserved UTXO returns to the wallet
     let funding = funding_broadcast_state(node1_addr).await;
     assert!(
-        funding.as_ref().map_or(true, |(_, in_mempool)| !*in_mempool),
+        funding.as_ref().is_none_or(|(_, in_mempool)| !*in_mempool),
         "the funding transaction must not be broadcast for a rejected open: {funding:?}"
     );
 

--- a/src/test/repro_util.rs
+++ b/src/test/repro_util.rs
@@ -1,0 +1,659 @@
+//! Evidence-collection helpers shared by the reproduction tests.
+//!
+//! Nodes run in-process, so the strongest evidence channel is a node's own data directory: this
+//! module snapshots it, diffs two snapshots and pretty-prints the result, so a test can show
+//! exactly which files a scenario created, removed or rewrote — and, via the same snapshots on a
+//! clean run, which of those also happen on the happy path.
+
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use lightning::ln::types::ChannelId;
+use lightning::util::ser::Writeable;
+
+use crate::disk::{read_channel_ids_info, CHANNEL_IDS_FNAME};
+
+use super::*;
+
+/// Files whose contents change on every run regardless of the scenario. Their size still shows up
+/// in a snapshot, but [`SnapshotDiff::excluding_volatile`] drops them so a diff stays readable.
+fn is_volatile(rel_path: &str) -> bool {
+    let file_name = file_name_of(rel_path);
+    rel_path.starts_with(".ldk/logs/") || file_name == LDK_LOGS_FILE || rel_path.ends_with("/log")
+}
+
+/// Whether a path inside a node directory holds RGB state. These are the files a repro test cares
+/// about, so they are the ones a snapshot hashes; everything else is recorded by size only.
+///
+/// Two groups: the rgb-lib wallet (`<fingerprint>/rgb/`, `rgb_lib_db`, `transfers/`, `assets/`,
+/// `media_files/`, `wallet_manifest.json`) and the RGB records LDK keeps beside its own state in
+/// `.ldk/` (consignments, funding PSBTs, per-transfer info, the RGB channel-info files named after
+/// a channel ID, and the former-temporary -> final channel ID map).
+fn is_rgb_related(rel_path: &str) -> bool {
+    let file_name = file_name_of(rel_path);
+
+    if rel_path.contains("/rgb/")
+        || rel_path.contains("/transfers/")
+        || rel_path.contains("/assets/")
+        || rel_path.contains("/media_files/")
+        || file_name == "rgb_lib_db"
+        || file_name == "wallet_manifest.json"
+    {
+        return true;
+    }
+
+    file_name == CHANNEL_IDS_FNAME
+        || file_name.starts_with("consignment_")
+        || file_name.starts_with("psbt_")
+        || file_name.ends_with("_transfer_info")
+        || is_channel_info_name(file_name)
+}
+
+/// RGB channel info is written to `.ldk/<channel_id>` (final) and `.ldk/<channel_id>.pending`.
+fn is_channel_info_name(file_name: &str) -> bool {
+    let stem = file_name.strip_suffix(".pending").unwrap_or(file_name);
+    stem.len() == 64 && stem.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn file_name_of(rel_path: &str) -> &str {
+    rel_path.rsplit('/').next().unwrap_or(rel_path)
+}
+
+fn short_hash(hash: &str) -> &str {
+    &hash[..hash.len().min(12)]
+}
+
+/// One file as recorded by a [`DirSnapshot`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FileEntry {
+    pub size: u64,
+    /// sha256 of the contents, computed only for RGB-related files (see [`is_rgb_related`]).
+    pub sha256: Option<String>,
+}
+
+impl FileEntry {
+    fn describe(&self) -> String {
+        match &self.sha256 {
+            Some(hash) => format!("{} bytes, sha256 {}", self.size, short_hash(hash)),
+            None => format!("{} bytes", self.size),
+        }
+    }
+}
+
+/// The state of a node data directory at one point in time: relative path -> entry, sorted.
+#[derive(Clone, Debug)]
+pub(crate) struct DirSnapshot {
+    /// what this snapshot is of, e.g. "node1 before the second open"
+    pub label: String,
+    pub root: PathBuf,
+    pub entries: BTreeMap<String, FileEntry>,
+}
+
+/// Snapshot a node's data directory (`tmp/<test>/node<N>`), recording every file's path relative
+/// to that directory and its size, plus the sha256 of RGB-related files.
+///
+/// A missing directory yields an empty snapshot rather than an error, so a test can snapshot
+/// before the node has been started.
+pub(crate) fn snapshot_node_dir(label: &str, node_test_dir: &str) -> DirSnapshot {
+    let root = PathBuf::from(node_test_dir);
+    let mut entries = BTreeMap::new();
+
+    for entry in walkdir::WalkDir::new(&root)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let Ok(rel) = entry.path().strip_prefix(&root) else {
+            continue;
+        };
+        let rel_path = rel.to_string_lossy().replace('\\', "/");
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let sha256 = if is_rgb_related(&rel_path) {
+            std::fs::read(entry.path())
+                .ok()
+                .map(|bytes| Sha256::hash(&bytes).to_string())
+        } else {
+            None
+        };
+        entries.insert(
+            rel_path,
+            FileEntry {
+                size: metadata.len(),
+                sha256,
+            },
+        );
+    }
+
+    DirSnapshot {
+        label: label.to_string(),
+        root,
+        entries,
+    }
+}
+
+impl DirSnapshot {
+    pub(crate) fn get(&self, rel_path: &str) -> Option<&FileEntry> {
+        self.entries.get(rel_path)
+    }
+
+    pub(crate) fn contains(&self, rel_path: &str) -> bool {
+        self.entries.contains_key(rel_path)
+    }
+
+    /// Paths satisfying `pred`, in sorted order — e.g. every consignment the node holds.
+    pub(crate) fn paths_matching<F: Fn(&str) -> bool>(&self, pred: F) -> Vec<String> {
+        self.entries.keys().filter(|p| pred(p)).cloned().collect()
+    }
+
+    /// Diff this snapshot (the "before") against a later one.
+    pub(crate) fn diff(&self, after: &DirSnapshot) -> SnapshotDiff {
+        assert_eq!(
+            self.root, after.root,
+            "refusing to diff snapshots of different node directories"
+        );
+
+        let mut diff = SnapshotDiff {
+            before_label: self.label.clone(),
+            after_label: after.label.clone(),
+            root: self.root.clone(),
+            ..Default::default()
+        };
+
+        for (path, before) in &self.entries {
+            match after.entries.get(path) {
+                None => diff.removed.push(EntryDiff {
+                    path: path.clone(),
+                    before: Some(before.clone()),
+                    after: None,
+                }),
+                Some(after_entry) if after_entry != before => diff.changed.push(EntryDiff {
+                    path: path.clone(),
+                    before: Some(before.clone()),
+                    after: Some(after_entry.clone()),
+                }),
+                Some(_) => {}
+            }
+        }
+
+        for (path, after_entry) in &after.entries {
+            if !self.entries.contains_key(path) {
+                diff.added.push(EntryDiff {
+                    path: path.clone(),
+                    before: None,
+                    after: Some(after_entry.clone()),
+                });
+            }
+        }
+
+        diff
+    }
+}
+
+/// One path that differs between two snapshots. `before` is `None` for an added file, `after` is
+/// `None` for a removed one.
+#[derive(Clone, Debug)]
+pub(crate) struct EntryDiff {
+    pub path: String,
+    pub before: Option<FileEntry>,
+    pub after: Option<FileEntry>,
+}
+
+/// The difference between two [`DirSnapshot`]s of the same node directory.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SnapshotDiff {
+    pub before_label: String,
+    pub after_label: String,
+    pub root: PathBuf,
+    pub added: Vec<EntryDiff>,
+    pub removed: Vec<EntryDiff>,
+    pub changed: Vec<EntryDiff>,
+}
+
+impl SnapshotDiff {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.changed.is_empty()
+    }
+
+    /// Every path that was added, removed or rewritten, sorted and deduplicated.
+    pub(crate) fn paths(&self) -> Vec<String> {
+        let mut paths: Vec<String> = self
+            .added
+            .iter()
+            .chain(&self.removed)
+            .chain(&self.changed)
+            .map(|e| e.path.clone())
+            .collect();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    pub(crate) fn added_paths(&self) -> Vec<String> {
+        self.added.iter().map(|e| e.path.clone()).collect()
+    }
+
+    pub(crate) fn removed_paths(&self) -> Vec<String> {
+        self.removed.iter().map(|e| e.path.clone()).collect()
+    }
+
+    pub(crate) fn changed_paths(&self) -> Vec<String> {
+        self.changed.iter().map(|e| e.path.clone()).collect()
+    }
+
+    pub(crate) fn filter<F: Fn(&str) -> bool>(&self, pred: F) -> SnapshotDiff {
+        let keep = |entries: &[EntryDiff]| -> Vec<EntryDiff> {
+            entries.iter().filter(|e| pred(&e.path)).cloned().collect()
+        };
+        SnapshotDiff {
+            before_label: self.before_label.clone(),
+            after_label: self.after_label.clone(),
+            root: self.root.clone(),
+            added: keep(&self.added),
+            removed: keep(&self.removed),
+            changed: keep(&self.changed),
+        }
+    }
+
+    /// Only the RGB state — the usual starting point when looking for residue.
+    pub(crate) fn rgb_only(&self) -> SnapshotDiff {
+        self.filter(is_rgb_related)
+    }
+
+    /// Drop the log files, which churn on every run and would otherwise swamp the output.
+    pub(crate) fn excluding_volatile(&self) -> SnapshotDiff {
+        self.filter(|path| !is_volatile(path))
+    }
+
+    pub(crate) fn pretty(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(
+            out,
+            "--- data dir diff [{}]: {} -> {}",
+            self.root.display(),
+            self.before_label,
+            self.after_label
+        );
+        if self.is_empty() {
+            let _ = writeln!(out, "  (no changes)");
+            return out;
+        }
+        for entry in &self.added {
+            let after = entry
+                .after
+                .as_ref()
+                .expect("added entry has an after state");
+            let _ = writeln!(out, "  + {} ({})", entry.path, after.describe());
+        }
+        for entry in &self.removed {
+            let before = entry
+                .before
+                .as_ref()
+                .expect("removed entry has a before state");
+            let _ = writeln!(out, "  - {} (was {})", entry.path, before.describe());
+        }
+        for entry in &self.changed {
+            let before = entry
+                .before
+                .as_ref()
+                .expect("changed entry has a before state");
+            let after = entry
+                .after
+                .as_ref()
+                .expect("changed entry has an after state");
+            let _ = writeln!(
+                out,
+                "  ~ {} ({} -> {})",
+                entry.path,
+                before.describe(),
+                after.describe()
+            );
+        }
+        out
+    }
+
+    /// Print the diff to the test's stdout (visible with `-- --nocapture`).
+    pub(crate) fn print(&self) {
+        print!("{}", self.pretty());
+    }
+}
+
+/// Path of the former-temporary -> final channel ID map inside a node's data directory.
+pub(crate) fn channel_ids_path(node_test_dir: &str) -> PathBuf {
+    PathBuf::from(node_test_dir)
+        .join(LDK_DIR)
+        .join(CHANNEL_IDS_FNAME)
+}
+
+/// The former-temporary -> final channel ID map as the node persisted it, as sorted
+/// `(temporary, final)` hex pairs. An absent or unreadable file reads as an empty map, exactly as
+/// the node itself reads it on startup (`disk::read_channel_ids_info`).
+pub(crate) fn channel_ids_on_disk(node_test_dir: &str) -> Vec<(String, String)> {
+    let mut entries: Vec<(String, String)> =
+        read_channel_ids_info(&channel_ids_path(node_test_dir))
+            .channel_ids
+            .iter()
+            .map(|(tmp, final_id)| (hex_str(&tmp.0), hex_str(&final_id.0)))
+            .collect();
+    entries.sort();
+    entries
+}
+
+/// Add a `temporary -> final` entry to a **stopped** node's persisted channel ID map. The node
+/// only reads the map from disk at startup, so this is the only way to hand it a map it would not
+/// have built itself.
+pub(crate) fn inject_channel_id_entry(node_test_dir: &str, temporary: &str, final_id: &str) {
+    let path = channel_ids_path(node_test_dir);
+    let mut map = read_channel_ids_info(&path);
+    map.channel_ids.insert(
+        channel_id_from_hex(temporary),
+        channel_id_from_hex(final_id),
+    );
+    std::fs::write(&path, map.encode()).unwrap();
+}
+
+fn channel_id_from_hex(hex: &str) -> ChannelId {
+    let bytes = hex_str_to_vec(hex).unwrap_or_else(|| panic!("{hex} is not valid hex"));
+    ChannelId(bytes.try_into().expect("a channel ID is 32 bytes"))
+}
+
+/// One output of a transaction, as bitcoind reports it.
+#[derive(Clone, Debug)]
+pub(crate) struct TxOutput {
+    pub index: u32,
+    pub sats: u64,
+    pub script_pubkey: String,
+    pub script_type: String,
+}
+
+impl TxOutput {
+    pub(crate) fn is_op_return(&self) -> bool {
+        self.script_type == "nulldata"
+    }
+}
+
+/// Every output of `txid`, in transaction order. The harness already has `tx_output_sats`, but a
+/// claim about *which* output holds something needs the scripts as well as the values.
+pub(crate) fn tx_outputs(txid: &str) -> Vec<TxOutput> {
+    let output = Command::new("docker")
+        .stdin(Stdio::null())
+        .arg("compose")
+        .args(bitcoin_cli())
+        .arg("getrawtransaction")
+        .arg(txid)
+        .arg("true")
+        .output()
+        .expect("able to call getrawtransaction");
+    assert!(output.status.success(), "no such transaction: {txid}");
+    let tx: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid tx JSON");
+    tx["vout"]
+        .as_array()
+        .expect("vout array")
+        .iter()
+        .map(|v| TxOutput {
+            index: v["n"].as_u64().expect("output index") as u32,
+            sats: Amount::from_btc(v["value"].as_f64().expect("output value"))
+                .expect("valid amount")
+                .to_sat(),
+            script_pubkey: v["scriptPubKey"]["hex"]
+                .as_str()
+                .expect("output script")
+                .to_string(),
+            script_type: v["scriptPubKey"]["type"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+        })
+        .collect()
+}
+
+/// Pretty-print a transaction's outputs, marking the funding one.
+pub(crate) fn print_tx_outputs(label: &str, txid: &str, funding_index: Option<u16>) {
+    println!("{label} {txid}");
+    for out in tx_outputs(txid) {
+        let marker = if Some(out.index as u16) == funding_index {
+            " <- channel funding output"
+        } else {
+            ""
+        };
+        println!(
+            "  vout {}: {:>10} sat  {:<12} {}{marker}",
+            out.index, out.sats, out.script_type, out.script_pubkey
+        );
+    }
+}
+
+/// The funding output index LDK settled on, recovered from the channel ID rather than from a guess
+/// about the transaction layout: a v1 channel ID is the funding txid with its last two bytes xored
+/// with the output index (`ChannelId::v1_from_funding_txid`), so exactly one index of the funding
+/// transaction reproduces the channel's ID.
+pub(crate) fn funding_output_index_of(
+    channel_id: &str,
+    funding_txid: &str,
+    num_outputs: usize,
+) -> u16 {
+    let txid = bitcoin::Txid::from_str(funding_txid).expect("valid funding txid");
+    let txid_bytes = Hash::as_byte_array(&txid);
+    (0..num_outputs as u16)
+        .find(|index| hex_str(&ChannelId::v1_from_funding_txid(txid_bytes, *index).0) == channel_id)
+        .unwrap_or_else(|| panic!("no output of {funding_txid} derives channel ID {channel_id}"))
+}
+
+/// The funding transaction a node built, read from the PSBT it persisted in `.ldk/psbt_<txid>`.
+/// Unlike [`tx_outputs`] this works for a funding that was never broadcast, which is the case
+/// whenever the open fails after the transaction was built. Returns `(txid, outputs)`.
+pub(crate) fn funding_psbt_outputs(node_test_dir: &str) -> (String, Vec<TxOutput>) {
+    let ldk_dir = PathBuf::from(node_test_dir).join(LDK_DIR);
+    let mut psbts: Vec<PathBuf> = std::fs::read_dir(&ldk_dir)
+        .expect("the node has an .ldk directory")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| file_name_of(&p.to_string_lossy()).starts_with("psbt_"))
+        .collect();
+    psbts.sort();
+    assert_eq!(
+        psbts.len(),
+        1,
+        "expected exactly one persisted funding PSBT, got {psbts:?}"
+    );
+    let txid = file_name_of(&psbts[0].to_string_lossy())
+        .trim_start_matches("psbt_")
+        .to_string();
+    let psbt = bitcoin::psbt::Psbt::from_str(&std::fs::read_to_string(&psbts[0]).unwrap())
+        .expect("a valid funding PSBT");
+    let outputs = psbt
+        .unsigned_tx
+        .output
+        .iter()
+        .enumerate()
+        .map(|(index, out)| TxOutput {
+            index: index as u32,
+            sats: out.value.to_sat(),
+            script_pubkey: out.script_pubkey.to_hex_string(),
+            script_type: script_type_of(&out.script_pubkey),
+        })
+        .collect();
+    (txid, outputs)
+}
+
+/// The `scriptPubKey.type` string bitcoind would report for a script, so that outputs read from a
+/// PSBT and outputs read from bitcoind describe themselves the same way.
+fn script_type_of(script: &bitcoin::ScriptBuf) -> String {
+    if script.is_op_return() {
+        s!("nulldata")
+    } else if script.is_p2wsh() {
+        s!("witness_v0_scripthash")
+    } else if script.is_p2wpkh() {
+        s!("witness_v0_keyhash")
+    } else if script.is_p2tr() {
+        s!("witness_v1_taproot")
+    } else {
+        s!("other")
+    }
+}
+
+/// Print outputs that were read from a PSBT rather than from bitcoind.
+pub(crate) fn print_outputs(
+    label: &str,
+    txid: &str,
+    outputs: &[TxOutput],
+    funding_index: Option<u16>,
+) {
+    println!("{label} {txid}");
+    for out in outputs {
+        let marker = if Some(out.index as u16) == funding_index {
+            " <- channel funding output"
+        } else {
+            ""
+        };
+        println!(
+            "  vout {}: {:>10} sat  {:<22} {}{marker}",
+            out.index, out.sats, out.script_type, out.script_pubkey
+        );
+    }
+}
+
+/// Exercises the snapshot/diff/print helpers on a throwaway directory laid out like a real node
+/// dir. Pure filesystem work: no regtest services, no node.
+#[serial_test::serial]
+#[test]
+fn repro_util_snapshot_diff() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_str().unwrap().to_string();
+    let ldk = tmp.path().join(LDK_DIR);
+    let wallet = tmp.path().join("0a58336b");
+    std::fs::create_dir_all(ldk.join("logs")).unwrap();
+    std::fs::create_dir_all(wallet.join("rgb")).unwrap();
+
+    let chan_a = "a".repeat(64);
+    std::fs::write(ldk.join(&chan_a), "{\"local\":100}").unwrap();
+    std::fs::write(ldk.join(format!("{chan_a}.pending")), "{\"local\":100}").unwrap();
+    std::fs::write(ldk.join(CHANNEL_IDS_FNAME), "one entry").unwrap();
+    std::fs::write(ldk.join("manager"), "ldk state").unwrap();
+    std::fs::write(ldk.join("logs").join(LDK_LOGS_FILE), "line one\n").unwrap();
+    std::fs::write(wallet.join("rgb").join("stash.dat"), "stash").unwrap();
+
+    let before = snapshot_node_dir("before", &root);
+    assert_eq!(before.entries.len(), 6);
+
+    // RGB-related files are hashed, everything else is recorded by size only
+    assert!(before
+        .get(&format!(".ldk/{chan_a}"))
+        .unwrap()
+        .sha256
+        .is_some());
+    assert!(before.get(".ldk/channel_ids").unwrap().sha256.is_some());
+    assert!(before
+        .get("0a58336b/rgb/stash.dat")
+        .unwrap()
+        .sha256
+        .is_some());
+    assert!(before.get(".ldk/manager").unwrap().sha256.is_none());
+    assert!(before.get(".ldk/logs/logs.txt").unwrap().sha256.is_none());
+
+    // a missing directory is an empty snapshot, not an error
+    assert!(
+        snapshot_node_dir("absent", &format!("{root}/does_not_exist"))
+            .entries
+            .is_empty()
+    );
+
+    // a scenario runs: one file appears, one is rewritten in place at the same size, one is
+    // removed, and the log churns
+    let chan_b = "b".repeat(64);
+    std::fs::write(ldk.join(&chan_b), "{\"local\":200}").unwrap();
+    std::fs::write(ldk.join(CHANNEL_IDS_FNAME), "two entries").unwrap();
+    std::fs::write(ldk.join(&chan_a), "{\"local\":999}").unwrap();
+    std::fs::remove_file(ldk.join(format!("{chan_a}.pending"))).unwrap();
+    std::fs::write(ldk.join("logs").join(LDK_LOGS_FILE), "line one\nline two\n").unwrap();
+
+    let after = snapshot_node_dir("after", &root);
+    let diff = before.diff(&after);
+    diff.print();
+
+    assert_eq!(diff.added_paths(), vec![format!(".ldk/{chan_b}")]);
+    assert_eq!(diff.removed_paths(), vec![format!(".ldk/{chan_a}.pending")]);
+    assert_eq!(
+        diff.changed_paths(),
+        vec![
+            format!(".ldk/{chan_a}"),
+            s!(".ldk/channel_ids"),
+            s!(".ldk/logs/logs.txt")
+        ]
+    );
+
+    // a same-size rewrite is still a change, because RGB-related files are compared by hash
+    let chan_a_diff = diff
+        .changed
+        .iter()
+        .find(|e| e.path == format!(".ldk/{chan_a}"))
+        .unwrap();
+    assert_eq!(
+        chan_a_diff.before.as_ref().unwrap().size,
+        chan_a_diff.after.as_ref().unwrap().size
+    );
+    assert_ne!(
+        chan_a_diff.before.as_ref().unwrap().sha256,
+        chan_a_diff.after.as_ref().unwrap().sha256
+    );
+
+    // filters
+    assert!(!diff
+        .excluding_volatile()
+        .changed_paths()
+        .contains(&s!(".ldk/logs/logs.txt")));
+    // the four RGB paths above; the log churn is not RGB state
+    assert_eq!(diff.rgb_only().paths().len(), 4);
+    assert_eq!(
+        after.paths_matching(|p| p.ends_with(".pending")),
+        Vec::<String>::new()
+    );
+
+    // pretty-printing marks each kind of change
+    let pretty = diff.pretty();
+    assert!(pretty.contains(&format!("+ .ldk/{chan_b}")));
+    assert!(pretty.contains(&format!("- .ldk/{chan_a}.pending")));
+    assert!(pretty.contains("~ .ldk/channel_ids"));
+
+    // and an unchanged directory diffs to nothing
+    let unchanged = snapshot_node_dir("unchanged", &root);
+    let empty = after.diff(&unchanged);
+    assert!(empty.is_empty(), "{}", empty.pretty());
+    assert!(empty.pretty().contains("(no changes)"));
+}
+
+/// The channel ID map helpers round-trip through the node's own encoding: what
+/// [`inject_channel_id_entry`] writes is what [`channel_ids_on_disk`] — and the node's
+/// `disk::read_channel_ids_info` — reads back.
+#[serial_test::serial]
+#[test]
+fn repro_util_channel_ids_map() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_str().unwrap().to_string();
+    std::fs::create_dir_all(tmp.path().join(LDK_DIR)).unwrap();
+
+    let temp_a = "a".repeat(64);
+    let temp_b = "b".repeat(64);
+    let final_a = "c".repeat(64);
+
+    // an absent file reads as an empty map, not an error
+    assert!(channel_ids_on_disk(&root).is_empty());
+
+    inject_channel_id_entry(&root, &temp_a, &final_a);
+    assert_eq!(
+        channel_ids_on_disk(&root),
+        vec![(temp_a.clone(), final_a.clone())]
+    );
+
+    // two temporary keys can map to one final ID
+    inject_channel_id_entry(&root, &temp_b, &final_a);
+    assert_eq!(
+        channel_ids_on_disk(&root),
+        vec![(temp_a, final_a.clone()), (temp_b, final_a)]
+    );
+}


### PR DESCRIPTION
Adds tests that reproduce [issue #160](https://github.com/RGB-Tools/rgb-lightning-node/issues/160):
during channel funding, the acceptor applies RGB and wallet side effects before the peer
message that triggered them is verified. A peer can send a well-formed but invalid
`funding_created` (unrelated consignment, unsupported assignment variant, out-of-range asset
push) and the node has already imported a consignment and mutated its RGB wallet by the time the
check fails — with no rollback. Some late checks are `unreachable!()` or an unchecked
subtraction, so peer input can panic the message handler instead of cleanly closing the channel.