### PR TITLE
test: failing tests for #158 — channel-ID / txid collisions

### DIFF
--- a/src/test/delete_channel_id.rs
+++ b/src/test/delete_channel_id.rs
@@ -1,0 +1,668 @@
+//! close cleanup removes the first reverse match in the channel-ID map.
+//!
+//! Two separate claims about the former-temporary -> final channel ID map live in `src/ldk.rs`:
+//!
+//! - [`UnlockedAppState::delete_channel_id`] (~429) scans the map for the *first* temporary key
+//!   whose **value** equals the closing channel's final ID and removes only that one, so a map
+//!   holding several temporary keys for one final ID keeps the rest.
+//! - [`UnlockedAppState::save_channel_ids_map`] (~448) `unwrap()`s the store write while holding
+//!   the map's `MutexGuard`, so a failed write panics with the guard alive.
+//!
+//! The tests here take them in order:
+//!
+//! - [`natural_flow_never_duplicates_a_final_id`] — route (a) of the plan and the baseline
+//!   (rule 4): a two-channel flow plus a re-open that reuses a freed temporary ID. It records what
+//!   correct cleanup looks like and whether the node can build the duplicate state on its own.
+//! - [`duplicate_reverse_entries_leave_a_stale_one`] — route (b): the duplicate entry is
+//!   written into the stopped node's `channel_ids` store, which is **weaker evidence** and is
+//!   labelled as such in the verdict.
+//! - [`channel_ids_write_failure_panics_and_poisons_the_map`] — the `unwrap()` probe: the
+//!   store write is made to fail by replacing `.ldk/channel_ids` with a directory, so `rename()`
+//!   onto it cannot succeed.
+
+use crate::test::repro_util::{
+    channel_ids_on_disk, channel_ids_path, inject_channel_id_entry, snapshot_node_dir,
+};
+
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/delete_channel_id/";
+
+/// Caller-supplied temporary channel ID for channel A (node1 -> node2).
+const TEMP_ID_A: &str = "0011223344556677889900112233445566778899001122334455667788990011";
+/// Caller-supplied temporary channel ID for channel B (node1 -> node3).
+const TEMP_ID_B: &str = "aabbccddeeff00112233445566778899aabbccddeeff001122334455667788ff";
+/// The second temporary ID injected into the stopped node's map, pointing at channel A.
+const TEMP_ID_DUP: &str = "deadbeef00000000deadbeef00000000deadbeef00000000deadbeef00000000";
+
+const CHAN_A_ASSET_AMT: u64 = 400;
+const CHAN_B_ASSET_AMT: u64 = 300;
+
+/// `/getchannelid` without the helper's built-in "must be 200" assertion, so a poisoned map — a
+/// panic in the handler, which drops the connection — is observable instead of fatal.
+async fn get_channel_id_res(
+    node_address: SocketAddr,
+    temporary_channel_id: &str,
+) -> Result<Response, reqwest::Error> {
+    let payload = GetChannelIdRequest {
+        temporary_channel_id: temporary_channel_id.to_string(),
+    };
+    reqwest::Client::new()
+        .post(format!("http://{node_address}/getchannelid"))
+        .json(&payload)
+        .send()
+        .await
+}
+
+/// `/openchannel` with only a temporary channel ID that is expected to be rejected before any
+/// channel work starts, tolerating a node that no longer answers at all.
+async fn open_channel_res(
+    node_address: SocketAddr,
+    peer_pubkey: &str,
+    peer_port: u16,
+    asset_id: &str,
+    temporary_channel_id: &str,
+) -> Result<Response, reqwest::Error> {
+    let payload = OpenChannelRequest {
+        peer_pubkey_and_opt_addr: format!("{peer_pubkey}@127.0.0.1:{peer_port}"),
+        capacity_sat: 100_000,
+        push_msat: 0,
+        asset_amount: Some(CHAN_B_ASSET_AMT),
+        asset_id: Some(asset_id.to_string()),
+        push_asset_amount: None,
+        public: true,
+        with_anchors: true,
+        fee_base_msat: None,
+        fee_proportional_millionths: None,
+        temporary_channel_id: Some(temporary_channel_id.to_string()),
+    };
+    reqwest::Client::new()
+        .post(format!("http://{node_address}/openchannel"))
+        .json(&payload)
+        .send()
+        .await
+}
+
+/// `/openchannel` for a plain vanilla channel, which never touches the channel ID map on the
+/// request path.
+async fn open_vanilla_channel_res(
+    node_address: SocketAddr,
+    peer_pubkey: &str,
+    peer_port: u16,
+) -> Result<Response, reqwest::Error> {
+    let payload = OpenChannelRequest {
+        peer_pubkey_and_opt_addr: format!("{peer_pubkey}@127.0.0.1:{peer_port}"),
+        capacity_sat: 100_000,
+        push_msat: 0,
+        asset_amount: None,
+        asset_id: None,
+        push_asset_amount: None,
+        public: true,
+        with_anchors: true,
+        fee_base_msat: None,
+        fee_proportional_millionths: None,
+        temporary_channel_id: None,
+    };
+    reqwest::Client::new()
+        .post(format!("http://{node_address}/openchannel"))
+        .json(&payload)
+        .send()
+        .await
+}
+
+/// Assert that `temporary_channel_id` is a live key of the map: `/openchannel` refuses to reuse it.
+async fn assert_temporary_id_is_taken(
+    node_address: SocketAddr,
+    peer_pubkey: &str,
+    peer_port: u16,
+    asset_id: &str,
+    temporary_channel_id: &str,
+) {
+    let res = open_channel_res(
+        node_address,
+        peer_pubkey,
+        peer_port,
+        asset_id,
+        temporary_channel_id,
+    )
+    .await
+    .expect("the node should still be answering /openchannel");
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::FORBIDDEN,
+        "Temporary channel ID already used",
+        "TemporaryChannelIdAlreadyUsed",
+    )
+    .await;
+}
+
+/// Assert that the map has no entry for `temporary_channel_id`, i.e. the ID is free again.
+async fn assert_temporary_id_is_unknown(node_address: SocketAddr, temporary_channel_id: &str) {
+    let res = get_channel_id_res(node_address, temporary_channel_id)
+        .await
+        .expect("the node should still be answering /getchannelid");
+    check_response_is_nok(
+        res,
+        reqwest::StatusCode::FORBIDDEN,
+        "Unknown temporary channel ID",
+        "UnknownTemporaryChannelId",
+    )
+    .await;
+}
+
+/// Poll the persisted map until `pred` holds, then return it. The map is written from the LDK
+/// event handler, so it lags the API state a close request reports.
+async fn wait_for_channel_ids<F>(node_test_dir: &str, what: &str, pred: F) -> Vec<(String, String)>
+where
+    F: Fn(&[(String, String)]) -> bool,
+{
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        let map = channel_ids_on_disk(node_test_dir);
+        if pred(&map) {
+            return map;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 60.0 {
+            panic!("timed out waiting for the channel_ids map to {what}, it holds {map:?}");
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+/// The temporary keys the persisted map points at `final_id`.
+fn keys_pointing_at(map: &[(String, String)], final_id: &str) -> Vec<String> {
+    map.iter()
+        .filter(|(_, v)| v == final_id)
+        .map(|(k, _)| k.clone())
+        .collect()
+}
+
+/// Whether any final channel ID appears as the value of more than one temporary key — the
+/// precondition `delete_channel_id`'s first-match scan needs to pick the wrong entry.
+fn has_duplicate_values(map: &[(String, String)]) -> bool {
+    let mut values: Vec<&String> = map.iter().map(|(_, v)| v).collect();
+    values.sort();
+    let total = values.len();
+    values.dedup();
+    values.len() != total
+}
+
+async fn wait_for_channel_gone(node_address: SocketAddr, channel_id: &str) {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        if !list_channels(node_address)
+            .await
+            .iter()
+            .any(|c| c.channel_id == channel_id)
+        {
+            return;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 60.0 {
+            panic!("channel {channel_id} is still open on node {node_address}");
+        }
+        mine_n_blocks(false, 1);
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+async fn wait_for_channel_ready(node_address: SocketAddr, channel_id: &str) {
+    let t_0 = OffsetDateTime::now_utc();
+    loop {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        if list_channels(node_address)
+            .await
+            .iter()
+            .any(|c| c.channel_id == channel_id && c.ready)
+        {
+            return;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 30.0 {
+            panic!("channel {channel_id} did not become ready again on node {node_address}");
+        }
+    }
+}
+
+/// Route (a) of the plan, and the baseline for rules 4 and 5: two live channels with
+/// caller-supplied temporary IDs, one of them closed, then re-opened reusing the freed temporary
+/// ID. Records what correct cleanup looks like and whether the node builds a map with two
+/// temporary keys for one final ID on its own.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn natural_flow_never_duplicates_a_final_id() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}natural/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let test_dir_node3 = format!("{test_dir_base}node3");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+    let (node3_addr, _) = start_node(&test_dir_node3, NODE3_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+    fund_and_create_utxos(node3_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    let node3_pubkey = node_info(node3_addr).await.pubkey;
+
+    println!("\nopening channel A (node1 -> node2) and channel B (node1 -> node3)");
+    let chan_a_id = open_channel_with_custom_data(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_A_ASSET_AMT),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        Some(TEMP_ID_A),
+        true,
+    )
+    .await
+    .channel_id;
+    let chan_b_id = open_channel_with_custom_data(
+        node1_addr,
+        &node3_pubkey,
+        Some(NODE3_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_B_ASSET_AMT),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        Some(TEMP_ID_B),
+        true,
+    )
+    .await
+    .channel_id;
+
+    let map = wait_for_channel_ids(&test_dir_node1, "hold both channels", |m| m.len() == 2).await;
+    println!("channel_ids map with both channels open: {map:?}");
+    assert_eq!(
+        map,
+        {
+            let mut expected = vec![
+                (TEMP_ID_A.to_string(), chan_a_id.clone()),
+                (TEMP_ID_B.to_string(), chan_b_id.clone()),
+            ];
+            expected.sort();
+            expected
+        },
+        "each channel contributes exactly one entry, keyed by its own temporary ID"
+    );
+    assert!(
+        !has_duplicate_values(&map),
+        "two live channels never share a final ID"
+    );
+    assert_eq!(get_channel_id(node1_addr, TEMP_ID_A).await, chan_a_id);
+    assert_eq!(get_channel_id(node1_addr, TEMP_ID_B).await, chan_b_id);
+
+    // --- baseline: closing channel A removes channel A's entry and nothing else
+    let before_close = snapshot_node_dir("node1 with both channels open", &test_dir_node1);
+    println!("\nclosing channel A");
+    close_channel(node1_addr, &chan_a_id, &node2_pubkey, false).await;
+    wait_for_balance(node1_addr, &asset_id, ISSUE_AMT - CHAN_B_ASSET_AMT).await;
+
+    let map =
+        wait_for_channel_ids(&test_dir_node1, "drop channel A's entry", |m| m.len() == 1).await;
+    println!("channel_ids map after closing channel A: {map:?}");
+    before_close
+        .diff(&snapshot_node_dir(
+            "node1 after closing channel A",
+            &test_dir_node1,
+        ))
+        .excluding_volatile()
+        .print();
+    assert_eq!(map, vec![(TEMP_ID_B.to_string(), chan_b_id.clone())]);
+    assert_temporary_id_is_unknown(node1_addr, TEMP_ID_A).await;
+    assert_eq!(
+        get_channel_id(node1_addr, TEMP_ID_B).await,
+        chan_b_id,
+        "the surviving channel's entry is untouched"
+    );
+
+    // --- the other half of route (a): re-open reusing the freed temporary ID
+    println!("\nre-opening a channel to node2 reusing channel A's temporary ID");
+    let chan_a2_id = open_channel_with_custom_data(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_A_ASSET_AMT),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        Some(TEMP_ID_A),
+        true,
+    )
+    .await
+    .channel_id;
+    assert_ne!(
+        chan_a2_id, chan_a_id,
+        "the re-opened channel has its own final ID"
+    );
+
+    let map = wait_for_channel_ids(&test_dir_node1, "hold both channels again", |m| {
+        m.len() == 2
+    })
+    .await;
+    println!("channel_ids map after the re-open: {map:?}");
+    assert_eq!(
+        map,
+        {
+            let mut expected = vec![
+                (TEMP_ID_A.to_string(), chan_a2_id.clone()),
+                (TEMP_ID_B.to_string(), chan_b_id.clone()),
+            ];
+            expected.sort();
+            expected
+        },
+        "the reused temporary ID points at the new channel, the old one is gone"
+    );
+    assert!(
+        !has_duplicate_values(&map),
+        "reusing a temporary ID does not create a second key for one final ID"
+    );
+
+    // --- and the reused entry is cleaned up correctly in turn
+    println!("\nclosing the re-opened channel");
+    close_channel(node1_addr, &chan_a2_id, &node2_pubkey, false).await;
+    wait_for_balance(node1_addr, &asset_id, ISSUE_AMT - CHAN_B_ASSET_AMT).await;
+    let map =
+        wait_for_channel_ids(&test_dir_node1, "drop the reused entry", |m| m.len() == 1).await;
+    assert_eq!(map, vec![(TEMP_ID_B.to_string(), chan_b_id)]);
+    assert_temporary_id_is_unknown(node1_addr, TEMP_ID_A).await;
+
+    println!(
+        "\nno step of this flow produced two temporary keys for one final ID: route (a) does not \
+         reach the precondition"
+    );
+}
+
+/// Route (b): the duplicate entry is injected into the stopped node's `channel_ids` store, since
+/// route (a) does not produce it. Closing the channel then removes an arbitrary one of the two
+/// keys and leaves the other pointing at a channel that no longer exists.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn duplicate_reverse_entries_leave_a_stale_one() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}duplicate/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    println!("\nopening channel A (node1 -> node2)");
+    let chan_a_id = open_channel_with_custom_data(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_A_ASSET_AMT),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        Some(TEMP_ID_A),
+        true,
+    )
+    .await
+    .channel_id;
+    wait_for_channel_ids(&test_dir_node1, "hold channel A", |m| m.len() == 1).await;
+    assert_eq!(get_channel_id(node1_addr, TEMP_ID_A).await, chan_a_id);
+
+    // --- the injection: a second temporary key for channel A's final ID
+    println!("\nstopping node1 to add a second temporary key for channel A");
+    shutdown(&[node1_addr]).await;
+    inject_channel_id_entry(&test_dir_node1, TEMP_ID_DUP, &chan_a_id);
+    let map = channel_ids_on_disk(&test_dir_node1);
+    println!("channel_ids map written while node1 was down: {map:?}");
+    assert_eq!(keys_pointing_at(&map, &chan_a_id).len(), 2);
+
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, true).await;
+    wait_for_channel_ready(node1_addr, &chan_a_id).await;
+
+    // both keys are live as far as the node is concerned
+    assert_eq!(get_channel_id(node1_addr, TEMP_ID_A).await, chan_a_id);
+    assert_eq!(get_channel_id(node1_addr, TEMP_ID_DUP).await, chan_a_id);
+    assert_temporary_id_is_taken(
+        node1_addr,
+        &node2_pubkey,
+        NODE2_PEER_PORT,
+        &asset_id,
+        TEMP_ID_DUP,
+    )
+    .await;
+
+    // --- the close: only one reverse match is removed
+    let before_close = snapshot_node_dir("node1 before closing channel A", &test_dir_node1);
+    println!("\nclosing channel A");
+    close_channel(node1_addr, &chan_a_id, &node2_pubkey, false).await;
+    wait_for_balance(node1_addr, &asset_id, ISSUE_AMT).await;
+    wait_for_channel_gone(node1_addr, &chan_a_id).await;
+    wait_for_channel_gone(node2_addr, &chan_a_id).await;
+
+    let map =
+        wait_for_channel_ids(&test_dir_node1, "shrink after the close", |m| m.len() < 2).await;
+    before_close
+        .diff(&snapshot_node_dir(
+            "node1 after closing channel A",
+            &test_dir_node1,
+        ))
+        .excluding_volatile()
+        .print();
+    println!("channel_ids map after closing channel A: {map:?}");
+
+    // EXPECTED AFTER FIX: close cleanup removes EVERY reverse entry pointing at the closed
+    // channel's final ID, so no stale temporary key is left behind
+    let survivors = keys_pointing_at(&map, &chan_a_id);
+    assert!(
+        survivors.is_empty(),
+        "both temporary keys pointing at the closed channel must be removed, map is {map:?}"
+    );
+    assert!(
+        map.is_empty(),
+        "the channel_ids map holds no residual entry after the close, map is {map:?}"
+    );
+
+    // EXPECTED AFTER FIX: neither temporary key resolves any more — both are free again, the way
+    // the baseline says a cleaned-up key should behave
+    assert!(
+        !list_channels(node1_addr)
+            .await
+            .iter()
+            .any(|c| c.channel_id == chan_a_id),
+        "node1 no longer has channel A"
+    );
+    assert_temporary_id_is_unknown(node1_addr, TEMP_ID_A).await;
+    assert_temporary_id_is_unknown(node1_addr, TEMP_ID_DUP).await;
+}
+
+/// The `unwrap()` probe: `save_channel_ids_map` writes through the LDK filesystem store, which
+/// renames a temporary file onto `.ldk/channel_ids`. Replacing that path with a directory makes
+/// the rename fail, so the write returns an error while the map's `MutexGuard` is still held.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn channel_ids_write_failure_panics_and_poisons_the_map() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}write_fail/");
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+
+    println!("\nopening channel A (node1 -> node2)");
+    let chan_a_id = open_channel_with_custom_data(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_A_ASSET_AMT),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        Some(TEMP_ID_A),
+        true,
+    )
+    .await
+    .channel_id;
+    wait_for_channel_ids(&test_dir_node1, "hold channel A", |m| m.len() == 1).await;
+    assert_eq!(get_channel_id(node1_addr, TEMP_ID_A).await, chan_a_id);
+
+    // --- the fault: the store can no longer write the map
+    let map_path = channel_ids_path(&test_dir_node1);
+    std::fs::remove_file(&map_path).unwrap();
+    std::fs::create_dir(&map_path).unwrap();
+    std::fs::write(map_path.join("keep"), "not empty").unwrap();
+    println!("\nreplaced {} with a directory", map_path.display());
+
+    // the in-memory map is untouched by that, so the node still answers from it
+    assert_eq!(get_channel_id(node1_addr, TEMP_ID_A).await, chan_a_id);
+
+    // --- the close reaches delete_channel_id -> save_channel_ids_map -> unwrap
+    println!("\nclosing channel A");
+    close_channel(node1_addr, &chan_a_id, &node2_pubkey, false).await;
+    wait_for_channel_gone(node1_addr, &chan_a_id).await;
+
+    // --- the map is dead: every read of it now hits the poisoned mutex and panics the handler,
+    // which drops the connection rather than returning a status
+    // EXPECTED AFTER FIX: a failed channel_ids write is handled gracefully, so the map is NOT
+    // poisoned — /getchannelid keeps completing with a normal status rather than dropping the
+    // connection or answering with a server error
+    let t_0 = OffsetDateTime::now_utc();
+    let mut poisoned = false;
+    loop {
+        match get_channel_id_res(node1_addr, TEMP_ID_A).await {
+            Err(e) => {
+                println!("/getchannelid no longer completes: {e}");
+                poisoned = true;
+                break;
+            }
+            Ok(res) => {
+                if res.status().is_server_error() {
+                    println!("/getchannelid answers {}", res.status());
+                    poisoned = true;
+                    break;
+                }
+            }
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 15.0 {
+            break;
+        }
+        mine_n_blocks(false, 1);
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+    assert!(
+        !poisoned,
+        "a failed channel_ids write must not take the map down or poison its mutex"
+    );
+
+    // EXPECTED AFTER FIX: the map is still healthy — /getchannelid completes with a normal status
+    // rather than a poisoned-mutex panic
+    let recovered = get_channel_id_res(node1_addr, TEMP_ID_A).await;
+    assert!(
+        recovered
+            .map(|r| !r.status().is_server_error())
+            .unwrap_or(false),
+        "the channel_ids map must stay usable after a failed write, not poison itself"
+    );
+    let open_res = open_channel_res(
+        node1_addr,
+        &node2_pubkey,
+        NODE2_PEER_PORT,
+        &asset_id,
+        TEMP_ID_B,
+    )
+    .await;
+    println!("/openchannel with a temporary channel ID answers: {open_res:?}");
+    // EXPECTED AFTER FIX: the duplicate check reads a healthy map, so /openchannel with a fresh
+    // temporary ID is not knocked out by a poisoned mutex
+    assert!(
+        open_res
+            .map(|r| !r.status().is_server_error())
+            .unwrap_or(false),
+        "/openchannel must still be able to run the channel_ids duplicate check"
+    );
+
+    // --- nothing was persisted: the map file is still the directory we put there
+    assert!(
+        channel_ids_path(&test_dir_node1).is_dir(),
+        "the store write must not have succeeded"
+    );
+
+    // --- scope of the damage, part 1: the read-only API still answers, so this is not simply a
+    // dead process
+    let channels = list_channels(node1_addr).await;
+    println!(
+        "node1 still answers /listchannels with {} channels",
+        channels.len()
+    );
+    assert!(!channels.iter().any(|c| c.channel_id == chan_a_id));
+    println!(
+        "node1 still answers /nodeinfo: {}",
+        node_info(node1_addr).await.pubkey
+    );
+
+    // EXPECTED AFTER FIX: the background processor survives the failed write, so LDK events keep
+    // being handled. A vanilla open skips the `channel_ids()` check, is accepted, and then funds
+    // normally because `FundingGenerationReady` still has a handler.
+    println!("\nopening a vanilla channel with no temporary channel ID");
+    let opened = open_vanilla_channel_res(node1_addr, &node2_pubkey, NODE2_PEER_PORT)
+        .await
+        .expect("the node should still be answering /openchannel without a temporary ID");
+    let status = opened.status();
+    println!("/openchannel without a temporary channel ID answers {status}");
+    assert!(
+        status.is_success(),
+        "nothing on the request path reads the channel ID map when no temporary ID is given"
+    );
+
+    let t_0 = OffsetDateTime::now_utc();
+    let funded = loop {
+        if list_channels(node1_addr).await.iter().any(|c| c.ready) {
+            break true;
+        }
+        if (OffsetDateTime::now_utc() - t_0).as_seconds_f32() > 45.0 {
+            break false;
+        }
+        mine_n_blocks(false, 1);
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    };
+    let channels = list_channels(node1_addr).await;
+    println!(
+        "45s after the accepted open, node1 has {} channel(s), ready: {:?}",
+        channels.len(),
+        channels.iter().map(|c| c.ready).collect::<Vec<_>>()
+    );
+    assert!(
+        funded,
+        "the background processor must survive the failed write and fund the channel"
+    );
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2371,6 +2371,7 @@ mod close_force_pending_htlc;
 mod close_force_standard;
 mod concurrent_btc_payments;
 mod concurrent_openchannel;
+mod delete_channel_id;
 mod drop_funding_signed;
 #[cfg(all(feature = "transaction-sync", feature = "electrum"))]
 mod electrum_opret_confirm;
@@ -2395,6 +2396,7 @@ mod out_of_band;
 mod payment;
 mod push_asset_amount_above_chan_amt;
 mod refuse_high_fees;
+mod repro_util;
 mod restart;
 mod send_receive;
 mod swap_assets_liquidity_both_ways;
@@ -2414,6 +2416,7 @@ mod swap_roundtrip_multihop_asset_asset;
 mod swap_roundtrip_multihop_buy;
 mod swap_roundtrip_multihop_sell;
 mod swap_roundtrip_sell;
+mod temp_channel_id_collision;
 #[cfg(feature = "transaction-sync")]
 mod transaction_sync;
 mod upload_asset_media;

--- a/src/test/repro_util.rs
+++ b/src/test/repro_util.rs
@@ -1,0 +1,505 @@
+//! Evidence-collection helpers shared by the audit reproduction tests.
+//!
+//! The audit plan (`docs/plans/2026-08-26-rln-channel-issue-repro.md`) requires every verdict to
+//! rest on observed state rather than on source reading. Nodes run in-process, so the strongest
+//! evidence channel is the node's own data directory: this module snapshots it, diffs two
+//! snapshots and pretty-prints the result so a repro test can show exactly which files a scenario
+//! created, removed or rewrote — and, by taking the same snapshots on a clean run, show which of
+//! those also happen on the happy path.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+
+use lightning::ln::types::ChannelId;
+use lightning::util::ser::Writeable;
+
+use crate::disk::{read_channel_ids_info, CHANNEL_IDS_FNAME};
+
+use super::*;
+
+/// Files whose contents change on every run regardless of the scenario. Their size still shows up
+/// in a snapshot, but [`SnapshotDiff::excluding_volatile`] drops them so a diff stays readable.
+fn is_volatile(rel_path: &str) -> bool {
+    let file_name = file_name_of(rel_path);
+    rel_path.starts_with(".ldk/logs/") || file_name == LDK_LOGS_FILE || rel_path.ends_with("/log")
+}
+
+/// Whether a path inside a node directory holds RGB state. These are the files a repro test cares
+/// about, so they are the ones a snapshot hashes; everything else is recorded by size only.
+///
+/// Two groups: the rgb-lib wallet (`<fingerprint>/rgb/`, `rgb_lib_db`, `transfers/`, `assets/`,
+/// `media_files/`, `wallet_manifest.json`) and the RGB records LDK keeps beside its own state in
+/// `.ldk/` (consignments, funding PSBTs, per-transfer info, the RGB channel-info files named after
+/// a channel ID, and the former-temporary -> final channel ID map).
+fn is_rgb_related(rel_path: &str) -> bool {
+    let file_name = file_name_of(rel_path);
+
+    if rel_path.contains("/rgb/")
+        || rel_path.contains("/transfers/")
+        || rel_path.contains("/assets/")
+        || rel_path.contains("/media_files/")
+        || file_name == "rgb_lib_db"
+        || file_name == "wallet_manifest.json"
+    {
+        return true;
+    }
+
+    file_name == CHANNEL_IDS_FNAME
+        || file_name.starts_with("consignment_")
+        || file_name.starts_with("psbt_")
+        || file_name.ends_with("_transfer_info")
+        || is_channel_info_name(file_name)
+}
+
+/// RGB channel info is written to `.ldk/<channel_id>` (final) and `.ldk/<channel_id>.pending`.
+fn is_channel_info_name(file_name: &str) -> bool {
+    let stem = file_name.strip_suffix(".pending").unwrap_or(file_name);
+    stem.len() == 64 && stem.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+fn file_name_of(rel_path: &str) -> &str {
+    rel_path.rsplit('/').next().unwrap_or(rel_path)
+}
+
+fn short_hash(hash: &str) -> &str {
+    &hash[..hash.len().min(12)]
+}
+
+/// One file as recorded by a [`DirSnapshot`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FileEntry {
+    pub size: u64,
+    /// sha256 of the contents, computed only for RGB-related files (see [`is_rgb_related`]).
+    pub sha256: Option<String>,
+}
+
+impl FileEntry {
+    fn describe(&self) -> String {
+        match &self.sha256 {
+            Some(hash) => format!("{} bytes, sha256 {}", self.size, short_hash(hash)),
+            None => format!("{} bytes", self.size),
+        }
+    }
+}
+
+/// The state of a node data directory at one point in time: relative path -> entry, sorted.
+#[derive(Clone, Debug)]
+pub(crate) struct DirSnapshot {
+    /// what this snapshot is of, e.g. "node1 before the second open"
+    pub label: String,
+    pub root: PathBuf,
+    pub entries: BTreeMap<String, FileEntry>,
+}
+
+/// Snapshot a node's data directory (`tmp/<test>/node<N>`), recording every file's path relative
+/// to that directory and its size, plus the sha256 of RGB-related files.
+///
+/// A missing directory yields an empty snapshot rather than an error, so a test can snapshot
+/// before the node has been started.
+pub(crate) fn snapshot_node_dir(label: &str, node_test_dir: &str) -> DirSnapshot {
+    let root = PathBuf::from(node_test_dir);
+    let mut entries = BTreeMap::new();
+
+    for entry in walkdir::WalkDir::new(&root)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let Ok(rel) = entry.path().strip_prefix(&root) else {
+            continue;
+        };
+        let rel_path = rel.to_string_lossy().replace('\\', "/");
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let sha256 = if is_rgb_related(&rel_path) {
+            std::fs::read(entry.path())
+                .ok()
+                .map(|bytes| Sha256::hash(&bytes).to_string())
+        } else {
+            None
+        };
+        entries.insert(
+            rel_path,
+            FileEntry {
+                size: metadata.len(),
+                sha256,
+            },
+        );
+    }
+
+    DirSnapshot {
+        label: label.to_string(),
+        root,
+        entries,
+    }
+}
+
+impl DirSnapshot {
+    pub(crate) fn get(&self, rel_path: &str) -> Option<&FileEntry> {
+        self.entries.get(rel_path)
+    }
+
+    pub(crate) fn contains(&self, rel_path: &str) -> bool {
+        self.entries.contains_key(rel_path)
+    }
+
+    /// Paths satisfying `pred`, in sorted order — e.g. every consignment the node holds.
+    pub(crate) fn paths_matching<F: Fn(&str) -> bool>(&self, pred: F) -> Vec<String> {
+        self.entries.keys().filter(|p| pred(p)).cloned().collect()
+    }
+
+    /// Diff this snapshot (the "before") against a later one.
+    pub(crate) fn diff(&self, after: &DirSnapshot) -> SnapshotDiff {
+        assert_eq!(
+            self.root, after.root,
+            "refusing to diff snapshots of different node directories"
+        );
+
+        let mut diff = SnapshotDiff {
+            before_label: self.label.clone(),
+            after_label: after.label.clone(),
+            root: self.root.clone(),
+            ..Default::default()
+        };
+
+        for (path, before) in &self.entries {
+            match after.entries.get(path) {
+                None => diff.removed.push(EntryDiff {
+                    path: path.clone(),
+                    before: Some(before.clone()),
+                    after: None,
+                }),
+                Some(after_entry) if after_entry != before => diff.changed.push(EntryDiff {
+                    path: path.clone(),
+                    before: Some(before.clone()),
+                    after: Some(after_entry.clone()),
+                }),
+                Some(_) => {}
+            }
+        }
+
+        for (path, after_entry) in &after.entries {
+            if !self.entries.contains_key(path) {
+                diff.added.push(EntryDiff {
+                    path: path.clone(),
+                    before: None,
+                    after: Some(after_entry.clone()),
+                });
+            }
+        }
+
+        diff
+    }
+}
+
+/// One path that differs between two snapshots. `before` is `None` for an added file, `after` is
+/// `None` for a removed one.
+#[derive(Clone, Debug)]
+pub(crate) struct EntryDiff {
+    pub path: String,
+    pub before: Option<FileEntry>,
+    pub after: Option<FileEntry>,
+}
+
+/// The difference between two [`DirSnapshot`]s of the same node directory.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SnapshotDiff {
+    pub before_label: String,
+    pub after_label: String,
+    pub root: PathBuf,
+    pub added: Vec<EntryDiff>,
+    pub removed: Vec<EntryDiff>,
+    pub changed: Vec<EntryDiff>,
+}
+
+impl SnapshotDiff {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty() && self.changed.is_empty()
+    }
+
+    /// Every path that was added, removed or rewritten, sorted and deduplicated.
+    pub(crate) fn paths(&self) -> Vec<String> {
+        let mut paths: Vec<String> = self
+            .added
+            .iter()
+            .chain(&self.removed)
+            .chain(&self.changed)
+            .map(|e| e.path.clone())
+            .collect();
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
+    pub(crate) fn added_paths(&self) -> Vec<String> {
+        self.added.iter().map(|e| e.path.clone()).collect()
+    }
+
+    pub(crate) fn removed_paths(&self) -> Vec<String> {
+        self.removed.iter().map(|e| e.path.clone()).collect()
+    }
+
+    pub(crate) fn changed_paths(&self) -> Vec<String> {
+        self.changed.iter().map(|e| e.path.clone()).collect()
+    }
+
+    pub(crate) fn filter<F: Fn(&str) -> bool>(&self, pred: F) -> SnapshotDiff {
+        let keep = |entries: &[EntryDiff]| -> Vec<EntryDiff> {
+            entries.iter().filter(|e| pred(&e.path)).cloned().collect()
+        };
+        SnapshotDiff {
+            before_label: self.before_label.clone(),
+            after_label: self.after_label.clone(),
+            root: self.root.clone(),
+            added: keep(&self.added),
+            removed: keep(&self.removed),
+            changed: keep(&self.changed),
+        }
+    }
+
+    /// Only the RGB state — the usual starting point when looking for residue.
+    pub(crate) fn rgb_only(&self) -> SnapshotDiff {
+        self.filter(is_rgb_related)
+    }
+
+    /// Drop the log files, which churn on every run and would otherwise swamp the output.
+    pub(crate) fn excluding_volatile(&self) -> SnapshotDiff {
+        self.filter(|path| !is_volatile(path))
+    }
+
+    pub(crate) fn pretty(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(
+            out,
+            "--- data dir diff [{}]: {} -> {}",
+            self.root.display(),
+            self.before_label,
+            self.after_label
+        );
+        if self.is_empty() {
+            let _ = writeln!(out, "  (no changes)");
+            return out;
+        }
+        for entry in &self.added {
+            let after = entry
+                .after
+                .as_ref()
+                .expect("added entry has an after state");
+            let _ = writeln!(out, "  + {} ({})", entry.path, after.describe());
+        }
+        for entry in &self.removed {
+            let before = entry
+                .before
+                .as_ref()
+                .expect("removed entry has a before state");
+            let _ = writeln!(out, "  - {} (was {})", entry.path, before.describe());
+        }
+        for entry in &self.changed {
+            let before = entry
+                .before
+                .as_ref()
+                .expect("changed entry has a before state");
+            let after = entry
+                .after
+                .as_ref()
+                .expect("changed entry has an after state");
+            let _ = writeln!(
+                out,
+                "  ~ {} ({} -> {})",
+                entry.path,
+                before.describe(),
+                after.describe()
+            );
+        }
+        out
+    }
+
+    /// Print the diff to the test's stdout (visible with `-- --nocapture`).
+    pub(crate) fn print(&self) {
+        print!("{}", self.pretty());
+    }
+}
+
+/// Path of the former-temporary -> final channel ID map inside a node's data directory.
+pub(crate) fn channel_ids_path(node_test_dir: &str) -> PathBuf {
+    PathBuf::from(node_test_dir)
+        .join(LDK_DIR)
+        .join(CHANNEL_IDS_FNAME)
+}
+
+/// The former-temporary -> final channel ID map as the node persisted it, as sorted
+/// `(temporary, final)` hex pairs. An absent or unreadable file reads as an empty map, exactly as
+/// the node itself reads it on startup (`disk::read_channel_ids_info`).
+pub(crate) fn channel_ids_on_disk(node_test_dir: &str) -> Vec<(String, String)> {
+    let mut entries: Vec<(String, String)> =
+        read_channel_ids_info(&channel_ids_path(node_test_dir))
+            .channel_ids
+            .iter()
+            .map(|(tmp, final_id)| (hex_str(&tmp.0), hex_str(&final_id.0)))
+            .collect();
+    entries.sort();
+    entries
+}
+
+/// Add a `temporary -> final` entry to a **stopped** node's persisted channel ID map. The node
+/// only reads the map from disk at startup, so this is the only way to hand it a map it would not
+/// have built itself. Evidence obtained this way is weaker than a state the node reaches on its
+/// own, and a verdict relying on it has to say so.
+pub(crate) fn inject_channel_id_entry(node_test_dir: &str, temporary: &str, final_id: &str) {
+    let path = channel_ids_path(node_test_dir);
+    let mut map = read_channel_ids_info(&path);
+    map.channel_ids.insert(
+        channel_id_from_hex(temporary),
+        channel_id_from_hex(final_id),
+    );
+    std::fs::write(&path, map.encode()).unwrap();
+}
+
+fn channel_id_from_hex(hex: &str) -> ChannelId {
+    let bytes = hex_str_to_vec(hex).unwrap_or_else(|| panic!("{hex} is not valid hex"));
+    ChannelId(bytes.try_into().expect("a channel ID is 32 bytes"))
+}
+
+/// Exercises the snapshot/diff/print helpers on a throwaway directory laid out like a real node
+/// dir. Pure filesystem work: no regtest services, no node.
+#[serial_test::serial]
+#[test]
+fn repro_util_snapshot_diff() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_str().unwrap().to_string();
+    let ldk = tmp.path().join(LDK_DIR);
+    let wallet = tmp.path().join("0a58336b");
+    std::fs::create_dir_all(ldk.join("logs")).unwrap();
+    std::fs::create_dir_all(wallet.join("rgb")).unwrap();
+
+    let chan_a = "a".repeat(64);
+    std::fs::write(ldk.join(&chan_a), "{\"local\":100}").unwrap();
+    std::fs::write(ldk.join(format!("{chan_a}.pending")), "{\"local\":100}").unwrap();
+    std::fs::write(ldk.join(CHANNEL_IDS_FNAME), "one entry").unwrap();
+    std::fs::write(ldk.join("manager"), "ldk state").unwrap();
+    std::fs::write(ldk.join("logs").join(LDK_LOGS_FILE), "line one\n").unwrap();
+    std::fs::write(wallet.join("rgb").join("stash.dat"), "stash").unwrap();
+
+    let before = snapshot_node_dir("before", &root);
+    assert_eq!(before.entries.len(), 6);
+
+    // RGB-related files are hashed, everything else is recorded by size only
+    assert!(before
+        .get(&format!(".ldk/{chan_a}"))
+        .unwrap()
+        .sha256
+        .is_some());
+    assert!(before.get(".ldk/channel_ids").unwrap().sha256.is_some());
+    assert!(before
+        .get("0a58336b/rgb/stash.dat")
+        .unwrap()
+        .sha256
+        .is_some());
+    assert!(before.get(".ldk/manager").unwrap().sha256.is_none());
+    assert!(before.get(".ldk/logs/logs.txt").unwrap().sha256.is_none());
+
+    // a missing directory is an empty snapshot, not an error
+    assert!(
+        snapshot_node_dir("absent", &format!("{root}/does_not_exist"))
+            .entries
+            .is_empty()
+    );
+
+    // a scenario runs: one file appears, one is rewritten in place at the same size, one is
+    // removed, and the log churns
+    let chan_b = "b".repeat(64);
+    std::fs::write(ldk.join(&chan_b), "{\"local\":200}").unwrap();
+    std::fs::write(ldk.join(CHANNEL_IDS_FNAME), "two entries").unwrap();
+    std::fs::write(ldk.join(&chan_a), "{\"local\":999}").unwrap();
+    std::fs::remove_file(ldk.join(format!("{chan_a}.pending"))).unwrap();
+    std::fs::write(ldk.join("logs").join(LDK_LOGS_FILE), "line one\nline two\n").unwrap();
+
+    let after = snapshot_node_dir("after", &root);
+    let diff = before.diff(&after);
+    diff.print();
+
+    assert_eq!(diff.added_paths(), vec![format!(".ldk/{chan_b}")]);
+    assert_eq!(diff.removed_paths(), vec![format!(".ldk/{chan_a}.pending")]);
+    assert_eq!(
+        diff.changed_paths(),
+        vec![
+            format!(".ldk/{chan_a}"),
+            s!(".ldk/channel_ids"),
+            s!(".ldk/logs/logs.txt")
+        ]
+    );
+
+    // a same-size rewrite is still a change, because RGB-related files are compared by hash
+    let chan_a_diff = diff
+        .changed
+        .iter()
+        .find(|e| e.path == format!(".ldk/{chan_a}"))
+        .unwrap();
+    assert_eq!(
+        chan_a_diff.before.as_ref().unwrap().size,
+        chan_a_diff.after.as_ref().unwrap().size
+    );
+    assert_ne!(
+        chan_a_diff.before.as_ref().unwrap().sha256,
+        chan_a_diff.after.as_ref().unwrap().sha256
+    );
+
+    // filters
+    assert!(!diff
+        .excluding_volatile()
+        .changed_paths()
+        .contains(&s!(".ldk/logs/logs.txt")));
+    // the four RGB paths above; the log churn is not RGB state
+    assert_eq!(diff.rgb_only().paths().len(), 4);
+    assert_eq!(
+        after.paths_matching(|p| p.ends_with(".pending")),
+        Vec::<String>::new()
+    );
+
+    // pretty-printing marks each kind of change
+    let pretty = diff.pretty();
+    assert!(pretty.contains(&format!("+ .ldk/{chan_b}")));
+    assert!(pretty.contains(&format!("- .ldk/{chan_a}.pending")));
+    assert!(pretty.contains("~ .ldk/channel_ids"));
+
+    // and an unchanged directory diffs to nothing
+    let unchanged = snapshot_node_dir("unchanged", &root);
+    let empty = after.diff(&unchanged);
+    assert!(empty.is_empty(), "{}", empty.pretty());
+    assert!(empty.pretty().contains("(no changes)"));
+}
+
+/// The channel ID map helpers round-trip through the node's own encoding: what
+/// [`inject_channel_id_entry`] writes is what [`channel_ids_on_disk`] — and the node's
+/// `disk::read_channel_ids_info` — reads back.
+#[serial_test::serial]
+#[test]
+fn repro_util_channel_ids_map() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().to_str().unwrap().to_string();
+    std::fs::create_dir_all(tmp.path().join(LDK_DIR)).unwrap();
+
+    let temp_a = "a".repeat(64);
+    let temp_b = "b".repeat(64);
+    let final_a = "c".repeat(64);
+
+    // an absent file reads as an empty map, not an error
+    assert!(channel_ids_on_disk(&root).is_empty());
+
+    inject_channel_id_entry(&root, &temp_a, &final_a);
+    assert_eq!(
+        channel_ids_on_disk(&root),
+        vec![(temp_a.clone(), final_a.clone())]
+    );
+
+    // two temporary keys for one final ID: the state the delete_channel_id test is about
+    inject_channel_id_entry(&root, &temp_b, &final_a);
+    assert_eq!(
+        channel_ids_on_disk(&root),
+        vec![(temp_a, final_a.clone()), (temp_b, final_a)]
+    );
+}

--- a/src/test/temp_channel_id_collision.rs
+++ b/src/test/temp_channel_id_collision.rs
@@ -1,0 +1,477 @@
+//! a caller-supplied `temporary_channel_id` can collide with another live channel.
+//!
+//! `POST /openchannel` rejects a caller-supplied temporary channel ID only when it is a **key** of
+//! the former-temporary -> final channel ID map (`src/routes.rs`, `channel_ids().contains_key`),
+//! and LDK's own duplicate check is per peer (`ChannelManager::create_channel`). A live channel's
+//! **final** ID is a *value* of that map and belongs to a different peer's channel set, so it
+//! passes both checks.
+//!
+//! Both halves of the claim are exercised here:
+//!
+//! - [`collision_with_final_channel_id`] — reuse channel A's final ID as the temporary ID of a
+//!   channel to another peer. This is the half the guards do not cover.
+//! - [`collision_with_temporary_channel_id`] — reuse channel A's temporary ID. The map key
+//!   check covers this one; the test pins that it stays covered.
+//! - [`baseline_distinct_temporary_ids`] — the same two-channel flow with a fresh temporary ID
+//!   for channel B, so that anything the collision run leaves behind can be compared against the
+//!   happy path (rule 4 of the plan).
+
+use lightning::rgb_utils::parse_rgb_channel_info;
+
+use super::repro_util::{channel_ids_on_disk, snapshot_node_dir};
+use super::*;
+
+const TEST_DIR_BASE: &str = "tmp/temp_channel_id_collision/";
+
+/// Caller-supplied temporary channel ID for channel A (node1 -> node2).
+const TEMP_ID_A: &str = "0011223344556677889900112233445566778899001122334455667788990011";
+/// A fresh, unused temporary channel ID — the baseline run gives it to channel B.
+const TEMP_ID_B: &str = "aabbccddeeff00112233445566778899aabbccddeeff001122334455667788ff";
+
+const CHAN_A_ASSET_AMT: u64 = 400;
+const CHAN_B_ASSET_AMT: u64 = 300;
+
+/// Path of the RGB channel-info file for `channel_id`, relative to a node's data directory.
+/// `.ldk/<channel_id>` holds the final info, `.ldk/<channel_id>.pending` the pending one.
+fn rgb_info_rel(channel_id: &str) -> String {
+    format!("{LDK_DIR}/{channel_id}")
+}
+
+fn rgb_info_pending_rel(channel_id: &str) -> String {
+    format!("{LDK_DIR}/{channel_id}.pending")
+}
+
+fn rgb_info_path(node_test_dir: &str, channel_id: &str) -> PathBuf {
+    PathBuf::from(node_test_dir).join(rgb_info_rel(channel_id))
+}
+
+/// `(local, remote)` asset amounts recorded in a channel's RGB info file, or `None` if the node
+/// has no RGB info for that channel ID at all.
+fn rgb_amounts_on_disk(node_test_dir: &str, channel_id: &str) -> Option<(u64, u64)> {
+    let path = rgb_info_path(node_test_dir, channel_id);
+    if !path.exists() {
+        return None;
+    }
+    let info = parse_rgb_channel_info(&path);
+    Some((info.local_rgb_amount, info.remote_rgb_amount))
+}
+
+/// `(asset_id, local, remote)` as the node's own API reports them for `channel_id`.
+async fn channel_asset_view(
+    node_address: SocketAddr,
+    channel_id: &str,
+) -> (Option<String>, Option<u64>, Option<u64>) {
+    let channels = list_channels(node_address).await;
+    let channel = channels
+        .iter()
+        .find(|c| c.channel_id == channel_id)
+        .unwrap_or_else(|| panic!("channel {channel_id} is gone from list_channels"));
+    (
+        channel.asset_id.clone(),
+        channel.asset_local_amount,
+        channel.asset_remote_amount,
+    )
+}
+
+/// `AssetBalanceResponse` is not `Debug`, and the off-chain fields are the interesting ones here.
+async fn balance_str(node_address: SocketAddr, asset_id: &str) -> String {
+    let b = asset_balance(node_address, asset_id).await;
+    format!(
+        "settled {} / future {} / spendable {} / offchain_outbound {} / offchain_inbound {}",
+        b.settled, b.future, b.spendable, b.offchain_outbound, b.offchain_inbound
+    )
+}
+
+/// Whether the node still answers `/listchannels`. A panic inside the `ChannelManager` poisons its
+/// locks, after which this stops being true.
+async fn channel_manager_alive(node_address: SocketAddr) -> bool {
+    reqwest::Client::new()
+        .get(format!("http://{node_address}/listchannels"))
+        .send()
+        .await
+        .map(|r| r.status().is_success())
+        .unwrap_or(false)
+}
+
+/// Shared prologue: three nodes, funded, with an NIA asset issued on node1 and a funded colored
+/// channel A from node1 to node2 opened under the caller-supplied [`TEMP_ID_A`].
+struct Setup {
+    node1_addr: SocketAddr,
+    node2_addr: SocketAddr,
+    node3_addr: SocketAddr,
+    test_dir_node1: String,
+    node2_pubkey: String,
+    node3_pubkey: String,
+    asset_id: String,
+    chan_a_id: String,
+}
+
+async fn setup(test_dir_base: &str) -> Setup {
+    let test_dir_node1 = format!("{test_dir_base}node1");
+    let test_dir_node2 = format!("{test_dir_base}node2");
+    let test_dir_node3 = format!("{test_dir_base}node3");
+    let (node1_addr, _) = start_node(&test_dir_node1, NODE1_PEER_PORT, false).await;
+    let (node2_addr, _) = start_node(&test_dir_node2, NODE2_PEER_PORT, false).await;
+    let (node3_addr, _) = start_node(&test_dir_node3, NODE3_PEER_PORT, false).await;
+
+    fund_and_create_utxos(node1_addr, None).await;
+    fund_and_create_utxos(node2_addr, None).await;
+    fund_and_create_utxos(node3_addr, None).await;
+
+    let asset_id = issue_asset_nia(node1_addr).await.asset_id;
+    let node2_pubkey = node_info(node2_addr).await.pubkey;
+    let node3_pubkey = node_info(node3_addr).await.pubkey;
+
+    println!("\nopening channel A (node1 -> node2) with the caller-supplied temporary ID");
+    let channel_a = open_channel_with_custom_data(
+        node1_addr,
+        &node2_pubkey,
+        Some(NODE2_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_A_ASSET_AMT),
+        Some(&asset_id),
+        None,
+        None,
+        None,
+        Some(TEMP_ID_A),
+        true,
+    )
+    .await;
+    let chan_a_id = channel_a.channel_id.clone();
+
+    // the map now holds TEMP_ID_A -> chan_a_id: the temporary ID is a key, the final ID a value
+    assert_eq!(get_channel_id(node1_addr, TEMP_ID_A).await, chan_a_id);
+    assert_eq!(
+        rgb_amounts_on_disk(&test_dir_node1, &chan_a_id),
+        Some((CHAN_A_ASSET_AMT, 0)),
+        "channel A's RGB info should record the amount it was opened with"
+    );
+    assert_eq!(
+        asset_balance_spendable(node1_addr, &asset_id).await,
+        ISSUE_AMT - CHAN_A_ASSET_AMT
+    );
+
+    Setup {
+        node1_addr,
+        node2_addr,
+        node3_addr,
+        test_dir_node1,
+        node2_pubkey,
+        node3_pubkey,
+        asset_id,
+        chan_a_id,
+    }
+}
+
+/// The claim itself: channel A's **final** ID is accepted as the temporary ID of a new channel to
+/// a different peer. Channel B's RGB info is written over channel A's, and funding channel B then
+/// renames channel A's RGB info away — after which node1's block-sync task panics reading it and
+/// the poisoned `ChannelManager` locks make every later channel operation fail.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn collision_with_final_channel_id() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}final_id/");
+    let s = setup(&test_dir_base).await;
+    let chan_a_id = s.chan_a_id.clone();
+
+    let before = snapshot_node_dir("node1 with only channel A", &s.test_dir_node1);
+    assert!(before.contains(&rgb_info_rel(&chan_a_id)));
+    assert!(before.contains(&rgb_info_pending_rel(&chan_a_id)));
+    assert_eq!(
+        channel_ids_on_disk(&s.test_dir_node1),
+        vec![(TEMP_ID_A.to_string(), chan_a_id.clone())],
+        "the map holds channel A's temporary ID as a key and its final ID as a value"
+    );
+
+    // --- the request itself: neither guard rejects a live channel's final ID
+    println!(
+        "\nopening channel B (node1 -> node3) reusing channel A's FINAL ID as the temporary one"
+    );
+    let opened = open_channel_raw(
+        s.node1_addr,
+        &s.node3_pubkey,
+        Some(NODE3_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_B_ASSET_AMT),
+        Some(&s.asset_id),
+        None,
+        None,
+        None,
+        Some(&chan_a_id),
+        true,
+        true,
+    )
+    .await;
+
+    let accepted = match opened {
+        Ok(response) => {
+            println!(
+                "request ACCEPTED, temporary channel ID: {}",
+                response.temporary_channel_id
+            );
+            assert_eq!(response.temporary_channel_id, chan_a_id);
+            true
+        }
+        Err(response) => {
+            println!("request REJECTED with status {}", response.status());
+            println!("body: {}", response.text().await.unwrap());
+            false
+        }
+    };
+    // EXPECTED AFTER FIX: a caller-supplied temporary channel ID that collides with a LIVE
+    // channel's FINAL ID is rejected, exactly as a collision with a temporary ID already is.
+    assert!(
+        !accepted,
+        "a caller-supplied temporary channel ID that collides with a live channel's final ID \
+         must be REJECTED, not accepted"
+    );
+
+    // EXPECTED AFTER FIX: the rejected open leaves channel A's RGB records untouched
+    let after_open = snapshot_node_dir("node1 right after the rejected open", &s.test_dir_node1);
+    let diff = before.diff(&after_open).excluding_volatile();
+    diff.print();
+    assert!(
+        !diff.changed_paths().contains(&rgb_info_rel(&chan_a_id)),
+        "channel A's RGB info file must be untouched by the rejected colliding open"
+    );
+    assert!(
+        !diff
+            .changed_paths()
+            .contains(&rgb_info_pending_rel(&chan_a_id)),
+        "channel A's pending RGB info file must be untouched by the rejected colliding open"
+    );
+
+    let preserved = rgb_amounts_on_disk(&s.test_dir_node1, &chan_a_id);
+    println!("channel A RGB info after the rejected open: {preserved:?}");
+    assert_eq!(
+        preserved,
+        Some((CHAN_A_ASSET_AMT, 0)),
+        "channel A's RGB info must still hold channel A's own amounts"
+    );
+    assert_eq!(
+        channel_asset_view(s.node1_addr, &chan_a_id).await,
+        (Some(s.asset_id.clone()), Some(CHAN_A_ASSET_AMT), Some(0)),
+        "node1 still reports channel A's own asset amounts"
+    );
+    assert_eq!(
+        channel_asset_view(s.node2_addr, &chan_a_id).await,
+        (Some(s.asset_id.clone()), Some(0), Some(CHAN_A_ASSET_AMT)),
+        "node2, which was not asked to reuse an ID, still has channel A right"
+    );
+
+    // EXPECTED AFTER FIX: channel A's RGB info files are NOT renamed away; both stay on disk
+    let chan_a_info_path = rgb_info_path(&s.test_dir_node1, &chan_a_id);
+    assert!(
+        chan_a_info_path.exists(),
+        "channel A's RGB info file must still exist after the rejected open"
+    );
+    assert!(
+        after_open.contains(&rgb_info_pending_rel(&chan_a_id)),
+        "channel A's pending RGB info file must still be present after the rejected open"
+    );
+
+    // EXPECTED AFTER FIX: the channel ID map still holds ONLY channel A's own entry — no
+    // A_tmp -> A -> B chain, and channel A's final ID never becomes a temporary key.
+    let map = channel_ids_on_disk(&s.test_dir_node1);
+    println!("channel_ids map on disk: {map:?}");
+    assert_eq!(
+        map,
+        vec![(TEMP_ID_A.to_string(), chan_a_id.clone())],
+        "the map must still hold only channel A's temporary -> final entry: {map:?}"
+    );
+
+    // EXPECTED AFTER FIX: node1 stays alive, still reports channel A as its own RGB channel, and
+    // its off-chain accounting still holds channel A's amount.
+    assert!(
+        channel_manager_alive(s.node1_addr).await,
+        "node1's ChannelManager must survive a rejected colliding open"
+    );
+    let view = channel_asset_view(s.node1_addr, &chan_a_id).await;
+    println!("node1's view of channel A after the rejected open: {view:?}");
+    assert_eq!(
+        view,
+        (Some(s.asset_id.clone()), Some(CHAN_A_ASSET_AMT), Some(0)),
+        "node1 still reports channel A as its own RGB channel"
+    );
+    let balance = asset_balance(s.node1_addr, &s.asset_id).await;
+    println!(
+        "node1 asset balance after the rejected open: {}",
+        balance_str(s.node1_addr, &s.asset_id).await
+    );
+    assert_eq!(
+        balance.offchain_outbound, CHAN_A_ASSET_AMT,
+        "channel A's {CHAN_A_ASSET_AMT} units must still be in node1's off-chain accounting"
+    );
+
+    // EXPECTED AFTER FIX: channel A's own temporary ID still resolves to channel A
+    assert_eq!(
+        get_channel_id(s.node1_addr, TEMP_ID_A).await,
+        chan_a_id,
+        "channel A's own temporary ID still resolves to channel A"
+    );
+
+    // node2 is untouched: it still holds channel A with the right amounts
+    assert_eq!(
+        channel_asset_view(s.node2_addr, &chan_a_id).await,
+        (Some(s.asset_id.clone()), Some(0), Some(CHAN_A_ASSET_AMT))
+    );
+
+    // EXPECTED AFTER FIX: channel A closes cleanly and returns its asset; node1's ChannelManager
+    // survives the close (the coloured-close path finds channel A's RGB info intact).
+    println!("\nasking node1 to close channel A");
+    close_channel(s.node1_addr, &chan_a_id, &s.node2_pubkey, false).await;
+    wait_for_balance(s.node1_addr, &s.asset_id, ISSUE_AMT).await;
+    assert!(
+        channel_manager_alive(s.node1_addr).await,
+        "node1's ChannelManager must survive closing channel A after a rejected colliding open"
+    );
+    println!(
+        "node1 asset balance after closing channel A: {}",
+        balance_str(s.node1_addr, &s.asset_id).await
+    );
+
+    let _ = s.node3_addr;
+}
+
+/// The other half of the claim: reusing channel A's **temporary** ID is caught by the map key
+/// check, so the request never reaches `create_channel`.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn collision_with_temporary_channel_id() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}temp_id/");
+    let s = setup(&test_dir_base).await;
+
+    let before = snapshot_node_dir("node1 with only channel A", &s.test_dir_node1);
+
+    println!("\nopening channel B (node1 -> node3) reusing channel A's TEMPORARY ID");
+    let opened = open_channel_raw(
+        s.node1_addr,
+        &s.node3_pubkey,
+        Some(NODE3_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_B_ASSET_AMT),
+        Some(&s.asset_id),
+        None,
+        None,
+        None,
+        Some(TEMP_ID_A),
+        true,
+        true,
+    )
+    .await;
+
+    let response = opened.expect_err(
+        "reusing a temporary ID that is a key of the channel_ids map should have been rejected",
+    );
+    check_response_is_nok(
+        *response,
+        reqwest::StatusCode::FORBIDDEN,
+        "Temporary channel ID already used",
+        "TemporaryChannelIdAlreadyUsed",
+    )
+    .await;
+
+    // a rejected request must not have touched any RGB state
+    let after = snapshot_node_dir("node1 after the rejected open", &s.test_dir_node1);
+    let diff = before.diff(&after).rgb_only();
+    diff.print();
+    assert!(
+        diff.is_empty(),
+        "the rejected open still changed RGB state: {}",
+        diff.pretty()
+    );
+    assert_eq!(
+        rgb_amounts_on_disk(&s.test_dir_node1, &s.chan_a_id),
+        Some((CHAN_A_ASSET_AMT, 0))
+    );
+    assert_eq!(
+        get_channel_id(s.node1_addr, TEMP_ID_A).await,
+        s.chan_a_id,
+        "the map entry for channel A must still point at channel A"
+    );
+
+    let _ = (s.node2_addr, s.node3_addr);
+}
+
+/// Baseline for rule 4: the same two-channel flow with a fresh temporary ID for channel B. Channel
+/// A keeps its own RGB info, both channels are reported with their own amounts, and channel A
+/// closes returning its asset — so anything different in the collision run is caused by the
+/// collision and not by opening a second channel.
+#[serial_test::serial]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[traced_test]
+async fn baseline_distinct_temporary_ids() {
+    initialize();
+
+    let test_dir_base = format!("{TEST_DIR_BASE}baseline/");
+    let s = setup(&test_dir_base).await;
+    let chan_a_id = s.chan_a_id.clone();
+
+    let before = snapshot_node_dir("node1 with only channel A", &s.test_dir_node1);
+
+    println!("\nopening channel B (node1 -> node3) with a fresh temporary ID");
+    let channel_b = open_channel_with_custom_data(
+        s.node1_addr,
+        &s.node3_pubkey,
+        Some(NODE3_PEER_PORT),
+        None,
+        None,
+        Some(CHAN_B_ASSET_AMT),
+        Some(&s.asset_id),
+        None,
+        None,
+        None,
+        Some(TEMP_ID_B),
+        true,
+    )
+    .await;
+    let chan_b_id = channel_b.channel_id.clone();
+
+    let after = snapshot_node_dir("node1 after channel B funded", &s.test_dir_node1);
+    before.diff(&after).excluding_volatile().print();
+
+    // both channels keep their own records
+    assert_eq!(
+        rgb_amounts_on_disk(&s.test_dir_node1, &chan_a_id),
+        Some((CHAN_A_ASSET_AMT, 0))
+    );
+    assert_eq!(
+        rgb_amounts_on_disk(&s.test_dir_node1, &chan_b_id),
+        Some((CHAN_B_ASSET_AMT, 0))
+    );
+    assert_eq!(
+        channel_asset_view(s.node1_addr, &chan_a_id).await,
+        (Some(s.asset_id.clone()), Some(CHAN_A_ASSET_AMT), Some(0))
+    );
+    assert_eq!(
+        channel_asset_view(s.node1_addr, &chan_b_id).await,
+        (Some(s.asset_id.clone()), Some(CHAN_B_ASSET_AMT), Some(0))
+    );
+    let balance = asset_balance(s.node1_addr, &s.asset_id).await;
+    assert_eq!(
+        balance.offchain_outbound,
+        CHAN_A_ASSET_AMT + CHAN_B_ASSET_AMT
+    );
+    assert_eq!(get_channel_id(s.node1_addr, TEMP_ID_A).await, chan_a_id);
+    assert_eq!(get_channel_id(s.node1_addr, TEMP_ID_B).await, chan_b_id);
+
+    // and channel A closes returning its asset
+    println!("\nclosing channel A");
+    close_channel(s.node1_addr, &chan_a_id, &s.node2_pubkey, false).await;
+    wait_for_balance(s.node1_addr, &s.asset_id, ISSUE_AMT - CHAN_B_ASSET_AMT).await;
+    println!(
+        "node1 asset balance after closing channel A: {}",
+        balance_str(s.node1_addr, &s.asset_id).await
+    );
+
+    let _ = s.node3_addr;
+}


### PR DESCRIPTION
Adds tests that reproduce
[issue #158](https://github.com/RGB-Tools/rgb-lightning-node/issues/158): channel files and
ID mappings are stored under a bare channel ID with no record of which peer or attempt owns
them. A caller-supplied `temporary_channel_id` that collides with another live channel's ID
passes the existing guards, and close cleanup removes only the first matching map entry — so
a collision or a duplicate mapping can overwrite, delete or misread another channel's records.
